### PR TITLE
Expand SEO schema, improve AI/LLM parsing, tighten interactions

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -1,5 +1,7 @@
 ---
 import "@styles/styles.scss";
+import fs from "node:fs";
+import path from "node:path";
 import type { TemplateConfig } from "utils/configType";
 
 const { backgroundGrid, seo, logo, theme, forceTheme, appStoreLink, name, appStore, home } =
@@ -24,9 +26,45 @@ const featureList = home?.features?.cards?.map((c) => c.title) ?? [
   "Offline Access",
 ];
 
-const screenshotUrls = (home?.header?.screenshots ?? ["/screenshots/trips-list.webp"]).map(
+// Discover every main iPhone screenshot at build time (skip -mobile variants
+// and numbered placeholder files), so the MobileApplication schema carries
+// a complete screenshot list for Google / Apple Intelligence / App carousels.
+const screenshotsDir = path.join(process.cwd(), "public", "screenshots");
+let discoveredScreenshots: string[] = [];
+try {
+  discoveredScreenshots = fs
+    .readdirSync(screenshotsDir)
+    .filter((f) => f.endsWith(".webp"))
+    .filter((f) => !f.includes("-mobile"))
+    .filter((f) => !/^\d+\.webp$/.test(f))
+    .sort();
+} catch {
+  discoveredScreenshots = [];
+}
+const heroScreenshots = home?.header?.screenshots ?? ["/screenshots/trips-list.webp"];
+const screenshotFileSet = new Set<string>([
+  ...heroScreenshots,
+  ...discoveredScreenshots.map((f) => `/screenshots/${f}`),
+]);
+const screenshotUrls = Array.from(screenshotFileSet).map(
   (s) => new URL(s, Astro.site).href,
 );
+
+// Entity graph @ids — let crawlers unify repeated references to the same thing.
+const siteId = `${Astro.site?.href ?? ""}#website`;
+const orgId = "https://www.12f.dk/#organization";
+const authorId = "https://www.12f.dk/#robert";
+const appId = `${Astro.site?.href ?? ""}#app`;
+
+const orgSameAs = [
+  "https://www.facebook.com/profile.php?id=61574251436717",
+  "https://www.instagram.com/travel_stories_app/",
+  appStoreLink,
+].filter((u): u is string => Boolean(u));
+
+// Publisher reference reused across Reviews / WebSite / App so the knowledge graph
+// collapses to a single Organization node.
+const publisherRef = { "@id": orgId };
 
 // FAQ schema is generated from config to stay in sync with what the user sees
 const faqEntities = (home?.faq?.qa ?? []).map((item) => ({
@@ -48,10 +86,13 @@ const howToSteps = (home?.howItWorks?.steps ?? []).map((step, index) => ({
   "url": `${canonicalURL.href}#how-it-works`,
 }));
 
-// Individual Review schema from testimonials for richer social proof
+// Reviews include a publisher reference so each one is attributed to the
+// first-party host — Google's review guidelines reward this.
 const reviewEntities = (home?.testimonials?.cards ?? []).map((t) => ({
   "@type": "Review",
   "author": { "@type": "Person", "name": t.name },
+  "publisher": publisherRef,
+  "itemReviewed": { "@id": appId },
   "reviewBody": t.comment,
   "reviewRating": {
     "@type": "Rating",
@@ -135,9 +176,11 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "MobileApplication",
+      "@id": appId,
       "name": "Travel Stories - Trip Planner",
       "alternateName": "Travel Stories",
       "operatingSystem": `iOS ${minimumOs}+`,
+      "availableOnDevice": "iPhone",
       "applicationCategory": "TravelApplication",
       "applicationSubCategory": "Trip Planner",
       "softwareVersion": appVersion,
@@ -145,12 +188,15 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
       ...(lastUpdated ? { "dateModified": lastUpdated } : {}),
       "inLanguage": "en",
       "featureList": featureList,
+      "sameAs": [appStoreLink].filter(Boolean),
       "offers": {
         "@type": "Offer",
         "price": appPrice,
         "priceCurrency": "USD",
         "availability": "https://schema.org/InStock",
-        "url": appStoreLink
+        "url": appStoreLink,
+        "eligibleRegion": { "@type": "Place", "name": "Worldwide" },
+        "seller": { "@id": orgId }
       },
       "aggregateRating": {
         "@type": "AggregateRating",
@@ -165,37 +211,47 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
       "installUrl": appStoreLink,
       "screenshot": screenshotUrls,
       "image": ogImage,
-      "author": {
-        "@type": "Person",
-        "name": "Robert Jensen",
-        "email": "robert@12f.dk",
-        "url": "https://www.12f.dk"
-      },
-      "publisher": {
-        "@type": "Organization",
-        "name": "12f.dk",
-        "url": "https://www.12f.dk",
-        "logo": ogImage
-      }
+      "author": { "@id": authorId },
+      "publisher": publisherRef
+    })} />
+
+    <!-- Structured Data - Author (Person) -->
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "@id": authorId,
+      "name": "Robert Jensen",
+      "email": "robert@12f.dk",
+      "url": "https://www.12f.dk",
+      "jobTitle": "Founder & Developer",
+      "worksFor": publisherRef
     })} />
 
     <!-- Structured Data - Organization -->
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Organization",
+      "@id": orgId,
       "name": "12f.dk",
       "url": "https://www.12f.dk",
-      "logo": ogImage,
-      "founder": {
-        "@type": "Person",
-        "name": "Robert Jensen"
+      "logo": {
+        "@type": "ImageObject",
+        "url": ogImage,
+        "caption": "12f.dk logo"
       },
-      "contactPoint": {
-        "@type": "ContactPoint",
-        "email": "robert@12f.dk",
-        "contactType": "customer support",
-        "availableLanguage": ["English"]
-      }
+      "image": ogImage,
+      "sameAs": orgSameAs,
+      "founder": { "@id": authorId },
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "email": "robert@12f.dk",
+          "contactType": "customer support",
+          "availableLanguage": ["English"],
+          "url": Astro.site?.href,
+          "areaServed": "Worldwide"
+        }
+      ]
     })} />
 
     {isHome && faqEntities.length > 0 && (
@@ -203,6 +259,10 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
         "@context": "https://schema.org",
         "@type": "FAQPage",
         "mainEntity": faqEntities,
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [".faq-item summary", ".faq-item summary + div"]
+        }
       })} />
     )}
 
@@ -244,20 +304,15 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
         "description": seo.description,
         "image": ogImage,
         "brand": { "@type": "Brand", "name": "Travel Stories" },
+        "mainEntityOfPage": { "@id": appId },
         "review": reviewEntities,
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "ratingValue": String(ratingValue),
-          "ratingCount": String(ratingCount),
-          "bestRating": "5",
-          "worstRating": "1",
-        },
       })} />
     )}
 
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
+      "@id": `${Astro.site?.href}#breadcrumb`,
       "itemListElement": [
         {
           "@type": "ListItem",
@@ -280,17 +335,45 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "WebSite",
+      "@id": siteId,
       "name": name,
       "alternateName": "Travel Stories - Trip Planner",
       "url": Astro.site?.href,
       "description": seo.description,
       "inLanguage": "en",
-      "publisher": {
-        "@type": "Organization",
-        "name": "12f.dk",
-        "url": "https://www.12f.dk"
-      }
+      "publisher": publisherRef,
+      ...(isHome ? { "mainEntity": { "@id": appId } } : {})
     })} />
+
+    {/* WebPage with speakable — lets voice assistants (Google Assistant,
+        Alexa via schema.org) read the hero headline, feature list, and FAQ
+        out loud. */}
+    {isHome && (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "@id": `${canonicalURL.href}#webpage`,
+        "url": canonicalURL.href,
+        "name": seo.title,
+        "description": seo.description,
+        "inLanguage": "en",
+        "isPartOf": { "@id": siteId },
+        "about": { "@id": appId },
+        "primaryImageOfPage": {
+          "@type": "ImageObject",
+          "url": ogImage
+        },
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [
+            "#hero-headline",
+            "#features-heading + div + ul",
+            ".faq-item"
+          ]
+        },
+        "breadcrumb": { "@id": `${Astro.site?.href}#breadcrumb` }
+      })} />
+    )}
 
     <script is:inline define:vars={{ forceTheme }}>
       function getPreferredColorScheme() {

--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -27,6 +27,41 @@ const featureList = home?.features?.cards?.map((c) => c.title) ?? [
 const screenshotUrls = (home?.header?.screenshots ?? ["/screenshots/trips-list.webp"]).map(
   (s) => new URL(s, Astro.site).href,
 );
+
+// FAQ schema is generated from config to stay in sync with what the user sees
+const faqEntities = (home?.faq?.qa ?? []).map((item) => ({
+  "@type": "Question",
+  "name": item.question,
+  "acceptedAnswer": {
+    "@type": "Answer",
+    "text": item.answer,
+  },
+}));
+
+// HowTo schema for the "How it works" steps — high-value signal for AI/search
+const howToSteps = (home?.howItWorks?.steps ?? []).map((step, index) => ({
+  "@type": "HowToStep",
+  "position": index + 1,
+  "name": step.title,
+  "text": step.subtitle,
+  ...(step.image ? { "image": new URL(step.image, Astro.site).href } : {}),
+  "url": `${canonicalURL.href}#how-it-works`,
+}));
+
+// Individual Review schema from testimonials for richer social proof
+const reviewEntities = (home?.testimonials?.cards ?? []).map((t) => ({
+  "@type": "Review",
+  "author": { "@type": "Person", "name": t.name },
+  "reviewBody": t.comment,
+  "reviewRating": {
+    "@type": "Rating",
+    "ratingValue": "5",
+    "bestRating": "5",
+    "worstRating": "1",
+  },
+}));
+
+const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
 ---
 
 <!doctype html>
@@ -62,6 +97,10 @@ const screenshotUrls = (home?.header?.screenshots ?? ["/screenshots/trips-list.w
     <meta name="author" content="Robert Jensen" />
     <meta name="publisher" content="12f.dk" />
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+    <meta name="theme-color" content="#007AFF" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0A84FF" media="(prefers-color-scheme: dark)" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="format-detection" content="telephone=no" />
 
     <!-- Hints for AI/LLM crawlers -->
     <link rel="alternate" type="text/markdown" title="LLM-friendly summary" href="/llms.txt" />
@@ -159,44 +198,82 @@ const screenshotUrls = (home?.header?.screenshots ?? ["/screenshots/trips-list.w
       }
     })} />
 
-    <!-- Structured Data - FAQ -->
+    {isHome && faqEntities.length > 0 && (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": faqEntities,
+      })} />
+    )}
+
+    {isHome && howToSteps.length > 0 && (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "HowTo",
+        "name": "How to plan a trip with Travel Stories",
+        "description": "Plan, organise, and remember your next adventure in five simple steps using the Travel Stories iPhone app.",
+        "totalTime": "PT10M",
+        "tool": [{ "@type": "HowToTool", "name": "Travel Stories iPhone app" }],
+        "step": howToSteps,
+        "image": ogImage,
+        "supply": [],
+      })} />
+    )}
+
+    {isHome && home?.features?.cards?.length ? (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "name": home.features.title,
+        "itemListOrder": "https://schema.org/ItemListOrderAscending",
+        "numberOfItems": home.features.cards.length,
+        "itemListElement": home.features.cards.map((c, i) => ({
+          "@type": "ListItem",
+          "position": i + 1,
+          "name": c.title,
+          "description": c.subtitle,
+        })),
+      })} />
+    ) : null}
+
+    {isHome && reviewEntities.length > 0 && (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Travel Stories - Trip Planner",
+        "description": seo.description,
+        "image": ogImage,
+        "brand": { "@type": "Brand", "name": "Travel Stories" },
+        "review": reviewEntities,
+        "aggregateRating": {
+          "@type": "AggregateRating",
+          "ratingValue": String(ratingValue),
+          "ratingCount": String(ratingCount),
+          "bestRating": "5",
+          "worstRating": "1",
+        },
+      })} />
+    )}
+
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
+      "@type": "BreadcrumbList",
+      "itemListElement": [
         {
-          "@type": "Question",
-          "name": "Is Travel Stories free to use?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes, it's free! We also offer a Premium Lifetime upgrade with more advanced features."
-          }
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": Astro.site?.href,
         },
-        {
-          "@type": "Question",
-          "name": "Does the app work offline?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Absolutely! Travel Stories is designed to work offline so you can access your itineraries, bookings, packing lists, and travel diary even in remote destinations without internet access."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "What devices are supported?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Travel Stories is currently available for iPhone and requires iOS 17.0 or later."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "How do I track my travel expenses?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Simply add expenses as you go during your trip. Travel Stories provides visual breakdowns by category so you can see exactly where your money is going and stay within your budget."
-          }
-        }
-      ]
+        ...(isHome
+          ? []
+          : [{
+              "@type": "ListItem",
+              "position": 2,
+              "name": seo.title.split("|")[0].trim(),
+              "item": canonicalURL.href,
+            }]),
+      ],
     })} />
 
     <!-- Structured Data - Website -->
@@ -233,6 +310,7 @@ const screenshotUrls = (home?.header?.screenshots ?? ["/screenshots/trips-list.w
     <script defer src="https://umami.robert-jensen.dk/script.js" data-website-id="48716c88-8707-4174-aef6-cff0c0aef35b"></script>
   </head>
   <body class="relative">
+    <a href="#main" class="skip-link">Skip to main content</a>
     {backgroundGrid && <div class="backgroundGrid" />}
     <slot />
   </body>

--- a/src/components/appBanner/index.tsx
+++ b/src/components/appBanner/index.tsx
@@ -14,6 +14,7 @@ function AppBanner() {
   return (
     <motion.section
       id={appBanner.id}
+      aria-labelledby="app-banner-heading"
       initial="hidden"
       whileInView="visible"
       viewport={{ once: true, amount: 0.4 }}
@@ -39,8 +40,10 @@ function AppBanner() {
         <div className="p-4 bg-primary text-primary-content rounded-t-[var(--rounded-box)] flex flex-col items-center md:flex-row">
           <div className="flex-1 flex flex-col items-center justify-center min-h-full">
             <motion.h2
+              id="app-banner-heading"
               initial={{ opacity: 0, y: "-100%" }}
-              animate={{ opacity: 1, y: 0 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
               transition={{ delay: 0.3 }}
               className="mt-0 mb-4 text-4xl md:text-6xl"
             >
@@ -62,10 +65,17 @@ function AppBanner() {
             >
               {googlePlayLink && (
                 <li className="m-0 p-0">
-                  <a href={googlePlayLink}>
+                  <a
+                    href={googlePlayLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-umami-event="footer-banner-google-play-click"
+                    aria-label="Download Travel Stories on Google Play"
+                    className="inline-block transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0"
+                  >
                     <img
                       className="h-14"
-                      alt="Download on Google Play"
+                      alt="Get it on Google Play"
                       src={withBase("/stores/google-play.svg")}
                       width={168}
                       height={56}
@@ -75,10 +85,17 @@ function AppBanner() {
               )}
               {appStoreLink && (
                 <li className="m-0 p-0">
-                  <a href={appStoreLink}>
+                  <a
+                    href={appStoreLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-umami-event="footer-banner-app-store-click"
+                    aria-label="Download Travel Stories on the Apple App Store"
+                    className="inline-block transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0"
+                  >
                     <img
                       className="h-14"
-                      alt="Download on App Store"
+                      alt="Download on the App Store"
                       src={withBase("/stores/app-store.svg")}
                       width={168}
                       height={56}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -29,8 +29,11 @@ function Navbar() {
     ease: easeIn,
   });
 
+  const closeMobileNav = () => setIsMobileNavVisible(false);
+
   return (
     <motion.nav
+      aria-label="Primary"
       className="opacity-0 max-w-screen-lg mx-auto sticky top-0 z-50"
       animate={{ opacity: 1 }}
     >
@@ -81,8 +84,19 @@ function Navbar() {
             ))}
           </ul>
           {topNavbar.cta && appStoreLink && (
-            <a href={appStoreLink} target="_blank" rel="noopener noreferrer" className="ml-3 btn py-4 bg-[#0066CC] hover:bg-[#0055AA] text-white border-none">
+            <a
+              href={appStoreLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-umami-event="navbar-cta-click"
+              aria-label={`${topNavbar.cta} — opens App Store in a new tab`}
+              className="ml-3 btn py-4 bg-primary hover:brightness-110 active:scale-95 transition-all text-primary-content border-none shadow-md shadow-primary/30"
+            >
               {topNavbar.cta}
+              <svg aria-hidden="true" viewBox="0 0 20 20" className="w-4 h-4 ml-1 fill-current opacity-90">
+                <path d="M11 3a1 1 0 1 0 0 2h2.586l-6.293 6.293a1 1 0 1 0 1.414 1.414L15 6.414V9a1 1 0 1 0 2 0V4a1 1 0 0 0-1-1h-5z"/>
+                <path d="M5 5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-3a1 1 0 1 0-2 0v3H5V7h3a1 1 0 0 0 0-2H5z"/>
+              </svg>
             </a>
           )}
         </div>
@@ -97,6 +111,7 @@ function Navbar() {
             key={index}
             className="btn btn-ghost w-full"
             href={href}
+            onClick={closeMobileNav}
             variants={{
               show: { x: 0 },
               hidden: { x: "-100%" },

--- a/src/modules/home/_components/faq/index.tsx
+++ b/src/modules/home/_components/faq/index.tsx
@@ -1,7 +1,5 @@
 import AnimatedText from "../../../../components/animatedText";
-import clsx from "clsx";
-import { motion } from "framer-motion";
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { ConfigContext } from "../../../../utils/configContext";
 import NeonHexagon from "./svgs/neonHexagon";
 
@@ -9,65 +7,48 @@ function Faq() {
   const {
     home: { faq },
   } = useContext(ConfigContext)!;
-  const [activeIndex, setActiveIndex] = useState<number>();
 
   if (!faq) return null;
 
   return (
-    <section id={faq.id} className="max-w-screen-lg mx-auto px-4 mb-12">
+    <section id={faq.id} aria-labelledby="faq-heading" className="max-w-screen-lg mx-auto px-4 mb-12">
       <div className="flex flex-col md:flex-row">
         <div className="relative flex-1 flex items-center">
           <NeonHexagon />
           <div className="h-full w-full flex items-center justify-center">
-            <h2 className="text-center font-bold text-3xl flex flex-col items-center mb-8 md:mb-0 md:text-left">
+            <h2
+              id="faq-heading"
+              className="text-center font-bold text-3xl flex flex-col items-center mb-8 md:mb-0 md:text-left"
+            >
               <AnimatedText text={faq.title} initial={{ y: "0%" }} />
             </h2>
           </div>
         </div>
-        <motion.div
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.4 }}
-          className="flex-1"
-        >
+        <ol role="list" className="flex-1 list-none p-0 m-0">
           {faq.qa.map((qa, index) => (
-            <motion.div
-              key={index}
-              variants={{
-                hidden: { opacity: 0 },
-                visible: { opacity: 1 },
-              }}
-              transition={{ delay: 0.25 + index * 0.25 }}
-              className={clsx(
-                "border-2 border-primary/30 my-2 collapse collapse-arrow",
-                {
-                  "collapse-open": activeIndex === index,
-                }
-              )}
-            >
-              <button
-                onClick={() =>
-                  setActiveIndex((current) =>
-                    current === index ? undefined : index
-                  )
-                }
-                className="text-start collapse-title text-lg font-medium"
+            <li key={index} role="listitem" className="m-0 p-0">
+              <details
+                className="faq-item group border-2 border-primary/20 hover:border-primary/40 focus-within:border-primary/60 rounded-2xl my-2 transition-colors duration-200"
+                style={{ animationDelay: `${index * 80}ms` }}
               >
-                {qa.question}
-              </button>
-              <div
-                className={clsx(
-                  "grid grid-rows-[0fr] duration-300 transition-[grid-template-rows,padding]",
-                  {
-                    "grid-rows-[1fr] pb-4": activeIndex === index,
-                  }
-                )}
-              >
-                <p className="overflow-hidden mx-4 text-base-content">{qa.answer}</p>
-              </div>
-            </motion.div>
+                <summary className="flex items-center justify-between gap-4 cursor-pointer list-none px-5 py-4 text-lg font-medium select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-2xl">
+                  <span>{qa.question}</span>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 20 20"
+                    className="shrink-0 w-5 h-5 text-primary transition-transform duration-300 group-open:rotate-45"
+                    fill="currentColor"
+                  >
+                    <path d="M10 3a1 1 0 0 1 1 1v5h5a1 1 0 1 1 0 2h-5v5a1 1 0 1 1-2 0v-5H4a1 1 0 1 1 0-2h5V4a1 1 0 0 1 1-1z" />
+                  </svg>
+                </summary>
+                <div className="px-5 pb-4 pt-0 text-base-content/90 leading-relaxed">
+                  {qa.answer}
+                </div>
+              </details>
+            </li>
           ))}
-        </motion.div>
+        </ol>
       </div>
     </section>
   );

--- a/src/modules/home/_components/features/index.tsx
+++ b/src/modules/home/_components/features/index.tsx
@@ -12,9 +12,13 @@ function Features() {
   if (!features) return null;
 
   return (
-    <section id={features.id} className="max-w-screen-lg mx-auto px-4 py-12">
+    <section
+      id={features.id}
+      aria-labelledby="features-heading"
+      className="max-w-screen-lg mx-auto px-4 py-12"
+    >
       <div className="mb-12 max-w-none flex flex-col items-center prose prose-lg text-center">
-        <h2 className="mb-3">
+        <h2 id="features-heading" className="mb-3">
           <AnimatedText text={features.title} />
         </h2>
         <motion.div
@@ -33,14 +37,14 @@ function Features() {
           </motion.p>
         )}
       </div>
-      <motion.div
+      <motion.ul
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6"
+        className="list-none p-0 m-0 grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6"
       >
         {features.cards.map((feat, index) => (
-          <motion.div
+          <motion.li
             key={index}
             variants={{
               hidden: { x: "-100%", opacity: 0 },
@@ -48,7 +52,7 @@ function Features() {
             }}
             transition={{ delay: 0.25 + index * 0.25 }}
             className={clsx(
-              "shadow-md border-primary/10 border-2 card relative overflow-hidden group px-12",
+              "shadow-md border-primary/10 border-2 card relative overflow-hidden group px-12 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 hover:border-primary/30",
               {
                 "col-span-2":
                   index === features!.cards.length - 1 &&
@@ -78,9 +82,9 @@ function Features() {
               <div className="h-0.5 w-full bg-primary/10" />
               <p className="text-base-content">{feat.subtitle}</p>
             </div>
-          </motion.div>
+          </motion.li>
         ))}
-      </motion.div>
+      </motion.ul>
     </section>
   );
 }

--- a/src/modules/home/_components/header/index.tsx
+++ b/src/modules/home/_components/header/index.tsx
@@ -20,7 +20,11 @@ function Header() {
   });
 
   return (
-    <section id={header.id} className="relative pb-8 md:pb-4">
+    <section
+      id={header.id}
+      aria-labelledby="hero-headline"
+      className="relative pb-8 md:pb-4"
+    >
       <div className="max-w-screen-lg mx-auto py-4 px-4 md:py-16">
         <div className="flex flex-col md:flex-row">
           <div className="flex flex-1 items-center md:items-start md:h-[300vh]">
@@ -42,6 +46,7 @@ function Header() {
                 ))}
               </div>
               <motion.h1
+                id="hero-headline"
                 initial={{ opacity: 0, rotateZ: -10 }}
                 animate={{ opacity: 1, rotateZ: 0 }}
                 className="mt-0 mb-4 text-4xl md:text-6xl"
@@ -93,10 +98,17 @@ function Header() {
               >
                 {googlePlayLink && (
                   <li className="m-0 p-0">
-                    <a href={googlePlayLink}>
+                    <a
+                      href={googlePlayLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-umami-event="hero-google-play-click"
+                      aria-label="Download Travel Stories on Google Play"
+                      className="inline-block transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0"
+                    >
                       <img
                         className="h-14"
-                        alt="google play logo"
+                        alt="Get it on Google Play"
                         src={withBase("/stores/google-play.svg")}
                         width={168}
                         height={56}
@@ -106,10 +118,17 @@ function Header() {
                 )}
                 {appStoreLink && (
                   <li className="m-0 p-0">
-                    <a href={appStoreLink}>
+                    <a
+                      href={appStoreLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-umami-event="hero-app-store-click"
+                      aria-label="Download Travel Stories on the Apple App Store"
+                      className="inline-block transition-transform duration-200 hover:-translate-y-0.5 active:translate-y-0"
+                    >
                       <img
                         className="h-14"
-                        alt="app store logo"
+                        alt="Download on the App Store"
                         src={withBase("/stores/app-store.svg")}
                         width={168}
                         height={56}

--- a/src/modules/home/_components/howItWorks/index.tsx
+++ b/src/modules/home/_components/howItWorks/index.tsx
@@ -18,10 +18,11 @@ function HowItWorks() {
   return (
     <section
       id={howItWorks.id}
+      aria-labelledby="how-it-works-heading"
       className="overflow-hidden max-w-screen-lg mx-auto px-4 py-12"
     >
       <div className="mb-12 max-w-none flex flex-col items-center prose prose-lg text-center">
-        <h2 className="mb-3">
+        <h2 id="how-it-works-heading" className="mb-3">
           <AnimatedText text={howItWorks.title} />
         </h2>
         {howItWorks.subtitle && (
@@ -35,9 +36,9 @@ function HowItWorks() {
           </motion.p>
         )}
       </div>
-      <div className="flex flex-col gap-52">
+      <ol className="list-none p-0 m-0 flex flex-col gap-52" role="list">
         {howItWorks.steps.map((step, index) => (
-          <motion.div
+          <motion.li
             key={index}
             initial="hidden"
             whileInView="visible"
@@ -105,17 +106,17 @@ function HowItWorks() {
               className="flex-1 flex justify-center"
             >
               <img
-                className="rounded-3xl lg:w-[75%]"
+                className="rounded-3xl lg:w-[75%] shadow-lg transition-transform duration-500 hover:scale-[1.02]"
                 src={withBase(step.image)}
-                alt={step.title}
+                alt={`Step ${index + 1}: ${step.title}`}
                 loading="lazy"
                 width={400}
                 height={300}
               />
             </motion.div>
-          </motion.div>
+          </motion.li>
         ))}
-      </div>
+      </ol>
     </section>
   );
 }

--- a/src/modules/home/_components/partners/index.tsx
+++ b/src/modules/home/_components/partners/index.tsx
@@ -8,7 +8,7 @@ function Partners() {
   const {
     home: { partners },
   } = useContext(ConfigContext)!;
-  if (!partners) return null;
+  if (!partners || !partners.logos?.length) return null;
 
   return (
     <section id={partners.id} className="relative p-4">

--- a/src/modules/home/_components/testimonials/index.tsx
+++ b/src/modules/home/_components/testimonials/index.tsx
@@ -1,11 +1,12 @@
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
+import "swiper/css/a11y";
 
 import AnimatedText from "../../../../components/animatedText";
 import { motion } from "framer-motion";
 import { useContext } from "react";
 import { ConfigContext } from "../../../../utils/configContext";
-import { Autoplay } from "swiper/modules";
+import { Autoplay, A11y, Keyboard } from "swiper/modules";
 
 function Testimonials() {
   const {
@@ -14,9 +15,12 @@ function Testimonials() {
   if (!testimonials) return null;
 
   return (
-    <section className="max-w-screen-lg mx-auto px-4 py-12">
+    <section
+      aria-labelledby="testimonials-heading"
+      className="max-w-screen-lg mx-auto px-4 py-12"
+    >
       <div className="mb-6 max-w-none flex flex-col items-center prose prose-lg text-center">
-        <h2 className="mb-0">
+        <h2 id="testimonials-heading" className="mb-0">
           <AnimatedText text={testimonials.title} />
         </h2>
         <motion.p
@@ -35,33 +39,60 @@ function Testimonials() {
       >
         <Swiper
           loop
-          autoplay
-          modules={[Autoplay]}
+          autoplay={{
+            delay: 5000,
+            disableOnInteraction: false,
+            pauseOnMouseEnter: true,
+          }}
+          a11y={{
+            enabled: true,
+            prevSlideMessage: "Previous testimonial",
+            nextSlideMessage: "Next testimonial",
+            slideLabelMessage: "Testimonial {{index}} of {{slidesLength}}",
+          }}
+          keyboard={{ enabled: true, onlyInViewport: true }}
+          modules={[Autoplay, A11y, Keyboard]}
           spaceBetween={32}
           breakpoints={{
             768: { slidesPerView: 2 },
             1024: { slidesPerView: 3 },
           }}
           slidesPerView={1}
+          aria-roledescription="carousel"
+          aria-label="Customer testimonials"
         >
           {testimonials.cards.map(({ name, comment }, index) => (
             <SwiperSlide className="!h-[22rem] my-2" key={index}>
-              <div className="h-full card shadow bg-primary">
+              <figure
+                role="group"
+                aria-roledescription="slide"
+                aria-label={`Testimonial ${index + 1} of ${testimonials.cards.length}`}
+                className="h-full card shadow-lg bg-primary transition-transform duration-300 hover:scale-[1.015]"
+              >
                 <div className="p-6 card-body">
-                  <div className="flex mb-4">
+                  <div
+                    className="flex mb-4"
+                    role="img"
+                    aria-label="Rated 5 out of 5 stars"
+                  >
                     {Array(5)
                       .fill(0)
                       .map((_, index) => (
                         <div
                           key={index}
+                          aria-hidden="true"
                           className="h-6 w-6 mask mask-star-2 bg-primary-content"
                         />
                       ))}
                   </div>
-                  <p className="text-primary-content">{comment}</p>
-                  <h3 className="card-title text-primary-content">{name}</h3>
+                  <blockquote className="text-primary-content m-0 p-0 border-0 not-italic before:content-none after:content-none">
+                    {comment}
+                  </blockquote>
+                  <figcaption className="card-title text-primary-content mt-auto">
+                    — {name}
+                  </figcaption>
                 </div>
-              </div>
+              </figure>
             </SwiperSlide>
           ))}
         </Swiper>

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -17,8 +17,8 @@ interface Props {
 function Home({ config }: Props) {
   return (
     <ConfigContext.Provider value={config}>
-      <main>
-        <Navbar />
+      <Navbar />
+      <main id="main">
         <Header />
         <Partners />
         <Features />
@@ -26,8 +26,8 @@ function Home({ config }: Props) {
         <Testimonials />
         <Faq />
         <AppBanner />
-        <Footer />
       </main>
+      <Footer />
     </ConfigContext.Provider>
   );
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -42,6 +42,70 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 6rem;
+}
+
+/* Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Accessible focus ring, global default */
+:focus-visible {
+  outline: 2px solid var(--fallback-p, #007AFF);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Skip to main content link for keyboard users */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+  background: #000;
+  color: #fff;
+  border-radius: 0 0 0.5rem 0;
+  font-weight: 600;
+}
+.skip-link:focus {
+  left: 0;
+}
+
+/* Remove the default triangle on native <details> */
+details > summary {
+  list-style: none;
+}
+details > summary::-webkit-details-marker {
+  display: none;
+}
+/* Smooth open animation for the FAQ */
+.faq-item[open] > div {
+  animation: faq-open 0.25s ease-out;
+}
+@keyframes faq-open {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Subtle fade-in for FAQ items; CSS-only so static HTML is crawler-visible */
+.faq-item {
+  animation: faq-fade-in 0.5s ease-out both;
+}
+@keyframes faq-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* Clean, modern body styling */


### PR DESCRIPTION
## Summary
- Expanded structured data: HowTo, BreadcrumbList, ItemList, Product+Review schemas, plus FAQ now generated from config so it stays in sync (previously hardcoded and missing Q5).
- Made FAQ friendlier to AI/LLM and non-JS crawlers by switching to native `<details>/<summary>` and removing the framer-motion `opacity:0` initial state.
- Tightened accessibility and interaction: skip-to-main link, proper `<main>` landmark, `aria-labelledby` per section, `:focus-visible` rings, `prefers-reduced-motion` handling, semantic `<ol>/<li>` for how-it-works steps and FAQ list.
- Navbar CTA opens App Store in a new tab with `rel=noopener`; store badges in hero + banner gain aria-labels and Umami events; mobile nav closes on link click; testimonials swiper gets `pauseOnMouseEnter` and a11y/keyboard modules.
- Added `theme-color`, `color-scheme`, `format-detection` meta; hid the empty Partners section when no logos are configured.

## Test plan
- [ ] `docker compose run --rm web pnpm build` completes without errors
- [ ] View generated `dist/index.html`: FAQPage, HowTo, BreadcrumbList, ItemList, Product, Review, MobileApplication, Organization, WebSite schemas all present
- [ ] All 5 FAQ `<details>` elements render without `opacity:0`
- [ ] Load `http://localhost:4321/` — navbar CTA has `target="_blank" rel="noopener noreferrer"`; skip-link visible on Tab; FAQ questions expand/collapse with + → × transition; mobile menu closes after tapping a link
- [ ] Validate JSON-LD with Google Rich Results Test after deploy