### PR TITLE
Honest social proof, geo-neutral App Store links, real pricing copy

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,13 +2,13 @@
 
 > Travel Stories is a free iPhone app for planning, organising, and remembering every adventure. It combines day-by-day itineraries with interactive maps, budget tracking, smart packing lists, booking storage, a photo travel diary, and full offline access.
 
-Travel Stories is published by Robert Jensen (12f.dk) and distributed exclusively on the Apple App Store. The app is free with an optional Premium Lifetime upgrade (19 DKK / ~$3 USD) that unlocks additional features. It requires iOS 17.0 or later and runs on iPhone. The public landing page is a static Astro site hosted at travel-stories.12f.dk.
+Travel Stories is published by Robert Jensen (12f.dk) and distributed exclusively on the Apple App Store. The app is free with an optional Premium Lifetime upgrade ($1.99 USD / 19 DKK) that unlocks additional features. It requires iOS 17.0 or later and runs on iPhone. The public landing page is a static Astro site hosted at travel-stories.12f.dk.
 
 ## Key facts
 
 - **Name:** Travel Stories - Trip Planner
 - **Platform:** iOS 17.0+ (iPhone)
-- **Price:** Free (Premium Lifetime upgrade: 19 DKK / ~$3 USD)
+- **Price:** Free (Premium Lifetime upgrade: $1.99 USD / 19 DKK)
 - **Category:** Travel
 - **Developer:** Robert Jensen (12f.dk), based in Denmark
 - **App Store ID:** 6756801168
@@ -36,7 +36,7 @@ Travelers who plan trips themselves and want one app to hold the itinerary, book
 
 ## Common questions
 
-- **Is it free?** Yes. There is an optional Premium Lifetime upgrade with additional features (19 DKK one-time).
+- **Is it free?** Yes. There is an optional Premium Lifetime upgrade with additional features ($1.99 / 19 DKK one-time, no subscription).
 - **Does it work offline?** Yes. Itineraries, bookings, packing lists, and the travel diary are all available without internet.
 - **What devices?** iPhone, iOS 17.0 or later. No Android or iPad-specific version yet.
 - **Can I share an itinerary with others?** Not yet — planned.

--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -10,9 +10,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 // square App Store icon, whose dimensions contradict og:image:width/height.
 const ogImage = new URL("/og-image.png", Astro.site).href;
 
-// Live rating/version from App Store lookup, with sensible fallbacks
-const ratingValue = appStore?.rating && appStore.rating > 0 ? appStore.rating : 5;
-const ratingCount = appStore?.ratingCount && appStore.ratingCount > 0 ? appStore.ratingCount : 1;
+// Live rating/version from App Store lookup. AggregateRating markup is only
+// emitted once there are enough real ratings to stand behind — a self-serving
+// 5.0/1 fallback is a structured-data manual-action risk, not social proof.
+const MIN_RATING_COUNT = 5;
+const hasTrustedRating =
+  (appStore?.rating ?? 0) > 0 && (appStore?.ratingCount ?? 0) >= MIN_RATING_COUNT;
 const appVersion = appStore?.version ?? "1.0.0";
 const appPrice = appStore?.price && appStore.price !== "Free" ? appStore.price : "0";
 const minimumOs = appStore?.minimumOsVersion ?? "17.0";
@@ -48,19 +51,6 @@ const howToSteps = (home?.howItWorks?.steps ?? []).map((step, index) => ({
   "text": step.subtitle,
   ...(step.image ? { "image": new URL(step.image, Astro.site).href } : {}),
   "url": `${canonicalURL.href}#how-it-works`,
-}));
-
-// Individual Review schema from testimonials for richer social proof
-const reviewEntities = (home?.testimonials?.cards ?? []).map((t) => ({
-  "@type": "Review",
-  "author": { "@type": "Person", "name": t.name },
-  "reviewBody": t.comment,
-  "reviewRating": {
-    "@type": "Rating",
-    "ratingValue": "5",
-    "bestRating": "5",
-    "worstRating": "1",
-  },
 }));
 
 const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
@@ -155,13 +145,17 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
         "availability": "https://schema.org/InStock",
         "url": appStoreLink
       },
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": String(ratingValue),
-        "ratingCount": String(ratingCount),
-        "bestRating": "5",
-        "worstRating": "1"
-      },
+      ...(hasTrustedRating
+        ? {
+            "aggregateRating": {
+              "@type": "AggregateRating",
+              "ratingValue": String(appStore!.rating),
+              "ratingCount": String(appStore!.ratingCount),
+              "bestRating": "5",
+              "worstRating": "1",
+            },
+          }
+        : {}),
       "description": seo.description,
       "url": canonicalURL.href,
       "downloadUrl": appStoreLink,
@@ -238,25 +232,6 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
         })),
       })} />
     ) : null}
-
-    {isHome && reviewEntities.length > 0 && (
-      <script type="application/ld+json" set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "Product",
-        "name": "Travel Stories - Trip Planner",
-        "description": seo.description,
-        "image": ogImage,
-        "brand": { "@type": "Brand", "name": "Travel Stories" },
-        "review": reviewEntities,
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "ratingValue": String(ratingValue),
-          "ratingCount": String(ratingCount),
-          "bestRating": "5",
-          "worstRating": "1",
-        },
-      })} />
-    )}
 
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",

--- a/src/modules/home/_components/header/index.tsx
+++ b/src/modules/home/_components/header/index.tsx
@@ -11,8 +11,13 @@ function Header() {
   const {
     googlePlayLink,
     appStoreLink,
+    appStore,
     home: { header, partners },
   } = useContext(ConfigContext)!;
+
+  // Only show a star rating that real users produced — never a hardcoded 5.0.
+  const hasTrustedRating =
+    (appStore?.rating ?? 0) > 0 && (appStore?.ratingCount ?? 0) >= 5;
 
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
@@ -144,17 +149,30 @@ function Header() {
                   transition={{ delay: 0.8 }}
                   className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-sm text-base-content/80"
                 >
-                  <div className="flex items-center gap-1.5">
-                    <div className="flex text-yellow-400" aria-label="5 out of 5 stars">
-                      {[...Array(5)].map((_, i) => (
-                        <svg key={i} className="w-4 h-4 fill-current" viewBox="0 0 20 20">
-                          <path d="M10 15l-5.878 3.09 1.123-6.545L.489 6.91l6.572-.955L10 0l2.939 5.955 6.572.955-4.756 4.635 1.123 6.545z" />
-                        </svg>
-                      ))}
-                    </div>
-                    <span className="font-medium">5.0</span>
-                  </div>
-                  <span className="hidden xs:inline">•</span>
+                  {hasTrustedRating && (
+                    <>
+                      <div className="flex items-center gap-1.5">
+                        <div
+                          className="flex text-yellow-400"
+                          aria-label={`${appStore!.rating.toFixed(1)} out of 5 stars`}
+                        >
+                          {[...Array(5)].map((_, i) => (
+                            <svg
+                              key={i}
+                              className={`w-4 h-4 fill-current ${i < Math.round(appStore!.rating) ? "" : "opacity-25"}`}
+                              viewBox="0 0 20 20"
+                            >
+                              <path d="M10 15l-5.878 3.09 1.123-6.545L.489 6.91l6.572-.955L10 0l2.939 5.955 6.572.955-4.756 4.635 1.123 6.545z" />
+                            </svg>
+                          ))}
+                        </div>
+                        <span className="font-medium">{appStore!.rating.toFixed(1)}</span>
+                      </div>
+                      <span className="hidden xs:inline">•</span>
+                    </>
+                  )}
+                  <span>Free download</span>
+                  <span>•</span>
                   <span>Works offline</span>
                   <span>•</span>
                   <span>No account needed</span>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,8 +15,9 @@ const templateConfig: TemplateConfig = {
   forceTheme: false,
   // Shows switch to toggle between dark and light modes
   showThemeSwitch: true,
-  appStoreLink:
-    "https://apps.apple.com/dk/app/travel-stories-trip-planner/id6756801168",
+  // Geo-neutral: Apple redirects to the visitor's own storefront. The /dk/
+  // path routed every international visitor through the Danish store.
+  appStoreLink: "https://apps.apple.com/app/id6756801168",
   googlePlayLink: "",
   footer: {
     legalLinks: {
@@ -61,28 +62,9 @@ const templateConfig: TemplateConfig = {
       description:
         "Travel Stories is a free iPhone app for planning, organising, and remembering every adventure. Create itineraries, track expenses, manage packing lists, and access everything offline. Download on the App Store.",
     },
-    testimonials: {
-      id: "testimonials",
-      title: "What Travelers Say",
-      subtitle: "Hear from adventurers using Travel Stories",
-      cards: [
-        {
-          name: "Sarah M.",
-          comment:
-            "Travel Stories completely transformed how I plan my trips. The day-by-day itinerary feature with interactive maps made navigating Tokyo so easy. I never missed a single activity!",
-        },
-        {
-          name: "Michael K.",
-          comment:
-            "The budget tracking feature is incredible. I used to always overspend on trips, but now I can see exactly where my money goes with the visual expense breakdowns. Saved me hundreds on my last Europe trip.",
-        },
-        {
-          name: "Emma L.",
-          comment:
-            "As someone who always forgets something when packing, the smart packing lists with 100+ suggested items are a lifesaver. The departure reminders also ensure I never miss a booking!",
-        },
-      ],
-    },
+    // Testimonials intentionally omitted until there are real App Store
+    // reviews to quote — invented reviewers cost more trust than they buy,
+    // and fake Review markup risks a structured-data manual action.
     partners: {
       title: "",
       logos: [],
@@ -164,7 +146,7 @@ const templateConfig: TemplateConfig = {
         {
           question: "Is Travel Stories free to use?",
           answer:
-            "Yes, it's free! We also offer a Premium Lifetime upgrade with more advanced features.",
+            "Yes — free to download and use. A one-time Premium upgrade (about $1.99) unlocks more advanced features. No subscription, ever.",
         },
         {
           question: "Does the app work offline?",


### PR DESCRIPTION
Re-creation of #27, which was auto-closed when its stacked base branch (`feature/14-blog-and-conversion`, PR #26) merged and was deleted. Same content, now rebased onto main. See #27 for the original description and verification notes.

- **#16 — fake social proof removed.** Invented testimonials gone from page and JSON-LD; `AggregateRating` trust-gated at ≥5 real ratings; hero hardcoded 5.0 replaced by gated live rating + honest "Free download" chip.
- **#17 — App Store links geo-neutral** (`apps.apple.com/app/id6756801168`); campaign tokens still pending ASC provider token.
- **#23 (partial) — real pricing copy** in FAQ + llms.txt ($1.99 / 19 DKK one-time, no subscription).

Verification: `pnpm build` passes (13 pages); built HTML has 0 fake reviewer names, 0 `aggregateRating` blocks (correct while <5 ratings), 0 `/dk/` App Store links.

Closes #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS