### PR TITLE
Add CI build gate on PRs (closes #34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# Build gate: run the exact production build on every PR into main, so a
+# content-schema violation (e.g. an over-length title) fails the PR instead of
+# landing on main and silently freezing the Pages deploy. See travel-stories issue #34 (same failure mode as home-stories #73).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site (validates content schema)
+        run: pnpm build


### PR DESCRIPTION
Ports home-stories' `ci.yml`: full `pnpm build` on every PR into main, so Zod content-schema violations (blog frontmatter) fail in CI rather than breaking the Pages deploy post-merge. Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS