### PR TITLE
Fix dark mode persistence (closes #28)

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -355,18 +355,18 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
       })} />
     )}
 
-    <script is:inline define:vars={{ forceTheme }}>
+    <script is:inline define:vars={{ forceTheme, theme }}>
+      const darkTheme = `${theme}-dark`;
       function getPreferredColorScheme() {
-        if (!window.matchMedia) {
-          return;
-        }
+        if (!window.matchMedia) return;
         if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          return "dark";
+          return darkTheme;
         }
       }
-      const theme = localStorage.getItem("theme") ?? getPreferredColorScheme();
-      if (theme === "dark" && !forceTheme)
-        document.documentElement.setAttribute("data-theme", theme);
+      const stored = localStorage.getItem("theme") ?? getPreferredColorScheme();
+      if (stored === darkTheme && !forceTheme) {
+        document.documentElement.setAttribute("data-theme", darkTheme);
+      }
     </script>
 
     <!-- Umami Analytics -->

--- a/src/components/navbar/themeSwitcher.tsx
+++ b/src/components/navbar/themeSwitcher.tsx
@@ -21,7 +21,12 @@ function ThemeSwitcher() {
     const theme = localStorage.getItem("theme") ?? getPreferredColorScheme();
     if (!theme) return;
     setMode(theme);
-  }, [darkTheme]);
+    // Re-apply on mount so the preference survives navigation even if the
+    // pre-paint inline script was skipped (e.g. bfcache restores).
+    if (theme === darkTheme || theme === lightTheme) {
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+  }, [darkTheme, lightTheme]);
 
   const isDarkMode = mode === darkTheme;
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -151,14 +151,18 @@ const breadcrumbSchema = {
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
     {articleSchema && <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />}
 
-    <script is:inline define:vars={{ forceTheme: config.forceTheme }}>
+    <script is:inline define:vars={{ forceTheme: config.forceTheme, theme: config.theme }}>
+      const darkTheme = `${theme}-dark`;
       function getPreferredColorScheme() {
         if (!window.matchMedia) return;
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          return darkTheme;
+        }
       }
-      const theme = localStorage.getItem("theme") ?? getPreferredColorScheme();
-      if (theme === "dark" && !forceTheme)
-        document.documentElement.setAttribute("data-theme", theme);
+      const stored = localStorage.getItem("theme") ?? getPreferredColorScheme();
+      if (stored === darkTheme && !forceTheme) {
+        document.documentElement.setAttribute("data-theme", darkTheme);
+      }
     </script>
 
     <script defer src="https://umami.robert-jensen.dk/script.js" data-website-id="48716c88-8707-4174-aef6-cff0c0aef35b"></script>


### PR DESCRIPTION
Pre-paint scripts in Layout.astro + BlogLayout.astro checked `theme === "dark"` while ThemeSwitcher stores `travel-dark` — dark preference lost on every reload. Ported the sister sites' no-flash script (derives `${theme}-dark`, honors `prefers-color-scheme`) into both layouts, plus ThemeSwitcher now re-applies `data-theme` on mount.

Verified end-to-end with agent-browser: toggle dark → reload → navigate to `/blog/` — `data-theme="travel-dark"` persists throughout. Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS