### PR TITLE
App Store lookup via US storefront + geo-neutral llms.txt link (#17)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -44,7 +44,7 @@ Travelers who plan trips themselves and want one app to hold the itinerary, book
 
 ## Links
 
-- [App Store listing](https://apps.apple.com/dk/app/travel-stories-trip-planner/id6756801168)
+- [App Store listing](https://apps.apple.com/app/id6756801168)
 - [Landing page](https://travel-stories.12f.dk)
 - [Features](https://travel-stories.12f.dk/#features)
 - [How it works](https://travel-stories.12f.dk/#how-it-works)

--- a/src/utils/appStoreData.ts
+++ b/src/utils/appStoreData.ts
@@ -26,7 +26,9 @@ interface AppStoreApiResponse {
 }
 
 const APP_ID = "6756801168";
-const COUNTRY = "dk";
+// US storefront: the largest review pool, so the trust-gated rating unlocks
+// as early as possible (see #17). Override with APP_STORE_COUNTRY if needed.
+const COUNTRY = process.env.APP_STORE_COUNTRY ?? "us";
 const API_URL = `https://itunes.apple.com/lookup?id=${APP_ID}&country=${COUNTRY}`;
 
 export async function fetchAppStoreData(): Promise<AppStoreData | null> {


### PR DESCRIPTION
Finishes the actionable remainder of #17: iTunes lookup now uses `country=us` (largest review pool → trust-gated rating unlocks earliest; `APP_STORE_COUNTRY` env override), and the last `/dk/`-locked App Store link (in `public/llms.txt`) is geo-neutral.

Verified the US lookup returns the app (v1.7.1, 2 ratings — rating stays correctly gated until ≥5).

NOT closing #17: `pt`/`ct` campaign attribution tokens still pending the ASC provider token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS