### PR TITLE
Homepage conversion sections: Facts, Use cases, mid-scroll CTAs, Comparison (closes #21)

### DIFF
--- a/src/components/sectionCta/index.tsx
+++ b/src/components/sectionCta/index.tsx
@@ -1,0 +1,54 @@
+import { motion } from "framer-motion";
+import { useContext } from "react";
+import { ConfigContext } from "../../utils/configContext";
+
+interface Props {
+  text: string;
+  /** Distinct Umami event name so each mid-scroll CTA is measurable. */
+  trackingId: string;
+}
+
+function AppleGlyph({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+}
+
+/**
+ * A one-line conversion bar placed between long sections — an extra
+ * download touchpoint for visitors who are already convinced mid-scroll.
+ */
+function SectionCta({ text, trackingId }: Props) {
+  const { appStoreLink } = useContext(ConfigContext)!;
+
+  if (!appStoreLink) return null;
+
+  return (
+    <div className="mx-auto max-w-screen-lg px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-60px" }}
+        className="flex flex-col items-center justify-between gap-5 border-y border-base-300 py-8 sm:flex-row"
+      >
+        <p className="text-center text-lg font-medium text-base-content sm:text-left md:text-xl">
+          {text}
+        </p>
+        <a
+          href={appStoreLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-umami-event={trackingId}
+          className="btn btn-primary gap-2 !text-white"
+        >
+          <AppleGlyph className="h-5 w-5" />
+          Download free
+        </a>
+      </motion.div>
+    </div>
+  );
+}
+
+export default SectionCta;

--- a/src/modules/home/_components/comparison/index.tsx
+++ b/src/modules/home/_components/comparison/index.tsx
@@ -1,0 +1,113 @@
+import { motion } from "framer-motion";
+import { useContext } from "react";
+import AnimatedText from "../../../../components/animatedText";
+import { ConfigContext } from "../../../../utils/configContext";
+
+/**
+ * The real competitor isn't another app — it's the notes-app / spreadsheet /
+ * group-chat chaos people already use. One honest table, no named rivals.
+ */
+function Comparison() {
+  const {
+    home: { comparison },
+  } = useContext(ConfigContext)!;
+  if (!comparison) return null;
+
+  return (
+    <section id={comparison.id} className="border-y border-base-300 bg-base-200/60">
+      <div className="mx-auto max-w-screen-lg px-4 py-16 md:py-24">
+        <div className="mb-10 max-w-none flex flex-col items-center prose prose-lg text-center">
+          <h2 className="mb-0">
+            <AnimatedText text={comparison.title} />
+          </h2>
+          {comparison.subtitle && (
+            <motion.p
+              initial={{ y: "50%", opacity: 0 }}
+              whileInView={{ y: "0%", opacity: 1 }}
+              viewport={{ once: true }}
+              className="text-xl max-w-lg text-base-content"
+            >
+              {comparison.subtitle}
+            </motion.p>
+          )}
+        </div>
+
+        {/* Mobile: one stacked card per aspect — no horizontal scroll. */}
+        <motion.dl
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+          className="divide-y divide-base-300 border-y border-base-300 md:hidden"
+        >
+          {comparison.rows.map((row) => (
+            <div key={row.aspect} className="py-5">
+              <dt className="text-xs uppercase tracking-widest text-base-content/50">
+                {row.aspect}
+              </dt>
+              <dd className="m-0 mt-2 text-sm leading-relaxed text-base-content/60">
+                <span className="mr-2 text-xs uppercase tracking-widest text-base-content/40">
+                  {comparison.columns.them}
+                </span>
+                {row.them}
+              </dd>
+              <dd className="m-0 mt-2 text-sm font-medium leading-relaxed text-base-content">
+                <span className="mr-2 text-xs uppercase tracking-widest text-primary">
+                  {comparison.columns.us}
+                </span>
+                {row.us}
+              </dd>
+            </div>
+          ))}
+        </motion.dl>
+
+        {/* Desktop: the honest three-column table. */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-80px" }}
+          transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+          className="hidden md:block"
+        >
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-base-300">
+                <th className="w-40 py-3 pr-4 text-left align-bottom" aria-label="Aspect" />
+                <th className="py-3 pr-4 text-left align-bottom font-normal">
+                  <span className="text-xs uppercase tracking-widest text-base-content/50">
+                    {comparison.columns.them}
+                  </span>
+                </th>
+                <th className="py-3 text-left align-bottom font-normal">
+                  <span className="flex items-center gap-2 text-xs uppercase tracking-widest text-base-content">
+                    <span className="inline-block h-0.5 w-4 bg-primary" aria-hidden="true" />
+                    {comparison.columns.us}
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-base-300">
+              {comparison.rows.map((row) => (
+                <tr key={row.aspect}>
+                  <td className="py-4 pr-4 align-top">
+                    <span className="text-xs uppercase tracking-widest text-base-content/50">
+                      {row.aspect}
+                    </span>
+                  </td>
+                  <td className="py-4 pr-4 align-top leading-relaxed text-base-content/60">
+                    {row.them}
+                  </td>
+                  <td className="py-4 align-top font-medium leading-relaxed text-base-content">
+                    {row.us}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+export default Comparison;

--- a/src/modules/home/_components/facts/index.tsx
+++ b/src/modules/home/_components/facts/index.tsx
@@ -1,0 +1,34 @@
+import { useContext } from "react";
+import { ConfigContext } from "../../../../utils/configContext";
+
+/**
+ * The things a person actually wants to know before they tap download,
+ * stated as verifiable facts rather than benefits. This is the site's
+ * trust layer now that invented testimonials are gone.
+ */
+function Facts() {
+  const {
+    home: { facts },
+  } = useContext(ConfigContext)!;
+
+  if (!facts?.length) return null;
+
+  return (
+    <section aria-label="At a glance" className="border-y border-base-300 bg-base-200/60">
+      <dl className="mx-auto grid max-w-screen-lg grid-cols-2 sm:grid-cols-3 md:grid-cols-5">
+        {facts.map(({ label, value }) => (
+          <div key={label} className="px-4 py-5 md:px-6 text-center">
+            <dt className="text-xs uppercase tracking-widest text-base-content/50">
+              {label}
+            </dt>
+            <dd className="mt-1 text-lg font-bold tracking-tight text-base-content">
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+export default Facts;

--- a/src/modules/home/_components/useCases/index.tsx
+++ b/src/modules/home/_components/useCases/index.tsx
@@ -1,0 +1,64 @@
+import { motion } from "framer-motion";
+import { useContext } from "react";
+import AnimatedText from "../../../../components/animatedText";
+import { ConfigContext } from "../../../../utils/configContext";
+
+function UseCases() {
+  const {
+    home: { useCases },
+  } = useContext(ConfigContext)!;
+  if (!useCases) return null;
+
+  return (
+    <section id={useCases.id} className="bg-base-200/60 border-y border-base-300">
+      <div className="mx-auto max-w-screen-lg px-4 py-16 md:py-24">
+        <div className="mb-12 max-w-none flex flex-col items-center prose prose-lg text-center">
+          <h2 className="mb-0">
+            <AnimatedText text={useCases.title} />
+          </h2>
+          {useCases.subtitle && (
+            <motion.p
+              initial={{ y: "50%", opacity: 0 }}
+              whileInView={{ y: "0%", opacity: 1 }}
+              viewport={{ once: true }}
+              className="text-xl max-w-lg text-base-content"
+            >
+              {useCases.subtitle}
+            </motion.p>
+          )}
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {useCases.cards.map((useCase, index) => (
+            <motion.article
+              key={useCase.title}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{
+                duration: 0.5,
+                delay: (index % 3) * 0.08,
+                ease: [0.16, 1, 0.3, 1],
+              }}
+              className="group relative overflow-hidden rounded-box border border-base-300 bg-base-100 p-6 shadow-sm"
+            >
+              <span
+                aria-hidden="true"
+                className="absolute inset-x-0 top-0 h-0.5 origin-left scale-x-0 bg-primary transition-transform duration-500 ease-out group-hover:scale-x-100"
+              />
+              <span className="text-4xl" role="img" aria-label={useCase.title}>
+                {useCase.emoji}
+              </span>
+              <h3 className="mt-4 text-xl font-semibold tracking-tight text-base-content">
+                {useCase.title}
+              </h3>
+              <p className="mt-2 text-base-content/70">{useCase.subtitle}</p>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default UseCases;

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -1,13 +1,17 @@
 import Navbar from "../../components/navbar";
 import Footer from "../../components/footer";
 import AppBanner from "../../components/appBanner";
+import SectionCta from "../../components/sectionCta";
 import { ConfigContext } from "../../utils/configContext";
 import type { TemplateConfig } from "../../utils/configType";
 import type { BlogTeaser } from "../../content/blog";
 import Header from "./_components/header";
+import Facts from "./_components/facts";
 import Features from "./_components/features";
+import UseCases from "./_components/useCases";
 import Faq from "./_components/faq";
 import HowItWorks from "./_components/howItWorks";
+import Comparison from "./_components/comparison";
 import Testimonials from "./_components/testimonials";
 import Pricing from "./_components/pricing";
 import FromTheBlog from "./_components/fromTheBlog";
@@ -23,8 +27,19 @@ function Home({ config, posts = [] }: Props) {
       <Navbar />
       <main id="main">
         <Header />
+        <Facts />
         <Features />
+        <UseCases />
+        <SectionCta
+          text="Ready to plan your next adventure?"
+          trackingId="cta-after-use-cases"
+        />
         <HowItWorks />
+        <Comparison />
+        <SectionCta
+          text="Leave the spreadsheet at home this time."
+          trackingId="cta-after-comparison"
+        />
         <Testimonials />
         <Pricing />
         <FromTheBlog posts={posts} />

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -69,6 +69,100 @@ const templateConfig: TemplateConfig = {
     // reviews to quote — invented reviewers cost more trust than they buy,
     // and fake Review markup risks a structured-data manual action.
     // Partners likewise omitted until there are real press/featured-on logos.
+    // Verifiable facts, not benefits — the trust layer replacing testimonials.
+    facts: [
+      { label: "Price", value: "Free" },
+      { label: "Works offline", value: "Fully" },
+      { label: "Account", value: "None needed" },
+      { label: "Requires", value: "iOS 17+" },
+      { label: "Made in", value: "Denmark" },
+    ],
+    useCases: {
+      id: "use-cases",
+      title: "Built for every kind of trip",
+      subtitle:
+        "From a spontaneous weekend away to a month-long expedition — one app for the whole journey.",
+      cards: [
+        {
+          emoji: "✈️",
+          title: "International vacation",
+          subtitle:
+            "Flights, hotels, documents, and a day-by-day plan — all offline once you land.",
+        },
+        {
+          emoji: "🚗",
+          title: "Road trip",
+          subtitle:
+            "Map the route, plan the stops, and log expenses while someone else drives.",
+        },
+        {
+          emoji: "💼",
+          title: "Business travel",
+          subtitle:
+            "Bookings and confirmation numbers in one place, expenses tracked for the report back home.",
+        },
+        {
+          emoji: "🏖️",
+          title: "Weekend getaway",
+          subtitle:
+            "A quick itinerary and a packing list in minutes — anticipation from the countdown widget.",
+        },
+        {
+          emoji: "🎒",
+          title: "Backpacking",
+          subtitle:
+            "Budget-first travel with visual spending breakdowns, built to work without data.",
+        },
+        {
+          emoji: "👨‍👩‍👧‍👦",
+          title: "Family holiday",
+          subtitle:
+            "Shared tasks before departure, everyone's packing lists, and a diary of the memories.",
+        },
+      ],
+    },
+    comparison: {
+      id: "comparison",
+      title: "Why not just notes and a spreadsheet?",
+      subtitle:
+        "That's how most trips are planned — until something gets lost in the group chat.",
+      columns: {
+        them: "Notes + spreadsheet",
+        us: "Travel Stories",
+      },
+      rows: [
+        {
+          aspect: "Itinerary",
+          them: "A wall of text you scroll through at the airport.",
+          us: "Day-by-day timeline with maps, times, and reminders.",
+        },
+        {
+          aspect: "Bookings",
+          them: "Confirmation numbers buried in your email.",
+          us: "Every flight, hotel, and tour stored with its details.",
+        },
+        {
+          aspect: "Budget",
+          them: "A spreadsheet you stop updating on day two.",
+          us: "Expenses logged in seconds, charted by category.",
+        },
+        {
+          aspect: "Packing",
+          them: "A new list from scratch every single trip.",
+          us: "Smart lists with 100+ suggestions, reused per trip type.",
+        },
+        {
+          aspect: "Offline",
+          them: "Cloud docs that won't open without a connection.",
+          us: "Everything works offline — built for airplane mode.",
+        },
+        {
+          aspect: "Memories",
+          them: "Photos scattered across your camera roll.",
+          us: "A travel diary that ties photos and notes to each day.",
+        },
+      ],
+    },
     howItWorks: {
       id: "how-it-works",
       title: "How it works",

--- a/src/utils/configType.ts
+++ b/src/utils/configType.ts
@@ -135,5 +135,33 @@ export type TemplateConfig = {
                 rows: string[];
             }[] | undefined;
         } | undefined;
+        facts?: {
+            label: string;
+            value: string;
+        }[] | undefined;
+        useCases?: {
+            id?: string | undefined;
+            title: string;
+            subtitle?: string | undefined;
+            cards: {
+                emoji: string;
+                title: string;
+                subtitle: string;
+            }[];
+        } | undefined;
+        comparison?: {
+            id?: string | undefined;
+            title: string;
+            subtitle?: string | undefined;
+            columns: {
+                them: string;
+                us: string;
+            };
+            rows: {
+                aspect: string;
+                them: string;
+                us: string;
+            }[];
+        } | undefined;
     };
 }


### PR DESCRIPTION
Brings the homepage to parity with the sister sites' engagement structure (adapted to travel-stories' own iOS-flavored design language rather than copying their letterpress/drafting themes). Details in the commit message.

Verified in-browser: facts strip, 6 use-case cards, both CTA bars with distinct Umami events, comparison table (desktop 3-col + mobile stacked). Build passes, 13 pages. Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS