### PR TITLE
Expand FAQ to 12 honest Q&As (closes #32)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -41,6 +41,12 @@ Travelers who plan trips themselves and want one app to hold the itinerary, book
 - **What devices?** iPhone, iOS 17.0 or later. No Android or iPad-specific version yet.
 - **Can I share an itinerary with others?** Yes — trip sharing and exports are included in the one-time Premium Lifetime upgrade.
 - **How is budget tracked?** Expenses are added manually during the trip and grouped by category for a visual breakdown.
+- **Do I need an account?** No — no sign-up, login, or email. Install and start planning.
+- **Where is data stored?** On the device. Trips, expenses, and photos are not uploaded to any server.
+- **Calendar export?** Yes — Premium exports the itinerary directly to Apple Calendar.
+- **Reminders?** Departure reminders (1–30 days ahead), task due-date alerts, booking reminders, and a Home Screen countdown widget.
+- **Save from other apps?** Yes — share bookings, links, and tips into a trip via the iOS share sheet.
+- **Languages?** 14, including English, German, French, Spanish, Italian, Dutch, Portuguese (BR), Swedish, Norwegian, Japanese, Korean, Traditional Chinese, Arabic, and Hebrew.
 
 ## Links
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -297,7 +297,42 @@ const templateConfig: TemplateConfig = {
         {
           question: "Can I share my itinerary with others?",
           answer:
-            "Not yet, but it's coming!",
+            "Yes — trip sharing and exports are part of the Premium Lifetime upgrade, so you can send your plan to travel companions.",
+        },
+        {
+          question: "Do I need to create an account?",
+          answer:
+            "No. There's no sign-up, no login, and no email required — download the app and start planning immediately.",
+        },
+        {
+          question: "Where is my travel data stored?",
+          answer:
+            "Everything stays on your iPhone. Travel Stories doesn't upload your trips, expenses, or photos to any server — your travel plans are yours alone.",
+        },
+        {
+          question: "Can I export my itinerary to my calendar?",
+          answer:
+            "Yes — with Premium you can export your itinerary directly to Apple Calendar, so departure times, activities, and bookings appear alongside the rest of your schedule.",
+        },
+        {
+          question: "Does it remind me about my trip and bookings?",
+          answer:
+            "Yes. You can set departure reminders (1–30 days before), task due-date alerts, and booking reminders for flights, hotels, and activities. A Home Screen widget counts down to departure day.",
+        },
+        {
+          question: "Can I save bookings and tips from other apps?",
+          answer:
+            "Yes — share flight confirmations, hotel links, restaurant tips, and articles straight from Mail, Safari, or any app into the right trip using the iOS share sheet.",
+        },
+        {
+          question: "What languages does the app support?",
+          answer:
+            "Travel Stories is available in 14 languages, including English, German, French, Spanish, Italian, Dutch, Portuguese, Swedish, Norwegian, Japanese, Korean, Traditional Chinese, Arabic, and Hebrew.",
+        },
+        {
+          question: "Is there an Android version?",
+          answer:
+            "No — Travel Stories is an iPhone app, and we're focused on making the best possible iOS experience. If that changes, it will be announced here first.",
         },
       ],
     },


### PR DESCRIPTION
FAQ grows 5 → 12 Q&As covering the objections travelers actually have (account, data privacy, calendar export, reminders, share-sheet capture, languages, Android), with llms.txt quick answers updated to match. Every claim was verified against the app's Swift source first — notably the app has NO iCloud sync (`cloudKitDatabase: .none`), so the data answer is 'stays on your iPhone' (a privacy plus), not a sync claim; and the stale 'sharing: not yet' answer is corrected (ShareTripSheet exists, Premium).

FAQPage JSON-LD emits all 12. Build passes. Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS