### PR TITLE
Consolidate JSON-LD into one @graph per page + Speakable (closes #24)

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -92,6 +92,196 @@ const howToSteps = (home?.howItWorks?.steps ?? []).map((step, index) => ({
 }));
 
 const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
+
+// ---------------------------------------------------------------------------
+// One consolidated JSON-LD @graph per page (event-stories pattern, #24).
+// Every node carries an @id so crawlers unify repeated references instead of
+// seeing eight disconnected scripts.
+// ---------------------------------------------------------------------------
+const breadcrumbId = `${canonicalURL.href}#breadcrumb`;
+
+const orgNode = {
+  "@type": "Organization",
+  "@id": orgId,
+  "name": "12f.dk",
+  "url": "https://www.12f.dk",
+  "logo": { "@type": "ImageObject", "url": ogImage, "caption": "12f.dk logo" },
+  "image": ogImage,
+  "sameAs": orgSameAs,
+  "founder": { "@id": authorId },
+  "contactPoint": [
+    {
+      "@type": "ContactPoint",
+      "email": "robert@12f.dk",
+      "contactType": "customer support",
+      "availableLanguage": ["English"],
+      "url": Astro.site?.href,
+      "areaServed": "Worldwide",
+    },
+  ],
+};
+
+const personNode = {
+  "@type": "Person",
+  "@id": authorId,
+  "name": "Robert Jensen",
+  "email": "robert@12f.dk",
+  "url": "https://www.12f.dk",
+  "jobTitle": "Founder & Developer",
+  "worksFor": publisherRef,
+};
+
+const webSiteNode = {
+  "@type": "WebSite",
+  "@id": siteId,
+  "name": name,
+  "alternateName": "Travel Stories - Trip Planner",
+  "url": Astro.site?.href,
+  "description": seo.description,
+  "inLanguage": "en",
+  "publisher": publisherRef,
+  ...(isHome ? { "mainEntity": { "@id": appId } } : {}),
+};
+
+const breadcrumbNode = {
+  "@type": "BreadcrumbList",
+  "@id": breadcrumbId,
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": Astro.site?.href },
+    ...(isHome
+      ? []
+      : [{
+          "@type": "ListItem",
+          "position": 2,
+          "name": seo.title.split("|")[0].trim(),
+          "item": canonicalURL.href,
+        }]),
+  ],
+};
+
+// WebPage on every page; speakable selectors only where they exist (home).
+const webPageNode = {
+  "@type": "WebPage",
+  "@id": `${canonicalURL.href}#webpage`,
+  "url": canonicalURL.href,
+  "name": seo.title,
+  "description": seo.description,
+  "inLanguage": "en",
+  "isPartOf": { "@id": siteId },
+  "primaryImageOfPage": { "@type": "ImageObject", "url": ogImage },
+  "breadcrumb": { "@id": breadcrumbId },
+  ...(isHome
+    ? {
+        "about": { "@id": appId },
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": ["#hero-headline", ".faq-item", "[data-speakable]"],
+        },
+      }
+    : {}),
+};
+
+const appNode = {
+  "@type": "MobileApplication",
+  "@id": appId,
+  "name": "Travel Stories - Trip Planner",
+  "alternateName": "Travel Stories",
+  "operatingSystem": `iOS ${minimumOs}+`,
+  "applicationCategory": "TravelApplication",
+  "applicationSubCategory": "Trip Planner",
+  "softwareVersion": appVersion,
+  "datePublished": "2026-01",
+  ...(lastUpdated ? { "dateModified": lastUpdated } : {}),
+  "inLanguage": "en",
+  "featureList": featureList,
+  "sameAs": [appStoreLink].filter(Boolean),
+  "offers": {
+    "@type": "Offer",
+    "price": appPrice,
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock",
+    "url": appStoreLink,
+    "eligibleRegion": { "@type": "Place", "name": "Worldwide" },
+    "seller": { "@id": orgId },
+    "description": "Free to download (1 trip included). Optional one-time Premium Lifetime in-app purchase ($1.99) unlocks unlimited trips, spending charts, calendar export, and sharing. No subscription.",
+  },
+  ...(hasTrustedRating
+    ? {
+        "aggregateRating": {
+          "@type": "AggregateRating",
+          "ratingValue": String(appStore!.rating),
+          "ratingCount": String(appStore!.ratingCount),
+          "bestRating": "5",
+          "worstRating": "1",
+        },
+      }
+    : {}),
+  "description": seo.description,
+  "url": canonicalURL.href,
+  "downloadUrl": appStoreLink,
+  "installUrl": appStoreLink,
+  "screenshot": screenshotUrls,
+  "image": ogImage,
+  "author": { "@id": authorId },
+  "publisher": publisherRef,
+};
+
+const faqNode =
+  isHome && faqEntities.length > 0
+    ? {
+        "@type": "FAQPage",
+        "@id": `${canonicalURL.href}#faq`,
+        "mainEntity": faqEntities,
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [".faq-item summary", ".faq-item summary + div"],
+        },
+      }
+    : null;
+
+const howToNode =
+  isHome && howToSteps.length > 0
+    ? {
+        "@type": "HowTo",
+        "@id": `${canonicalURL.href}#howto`,
+        "name": "How to plan a trip with Travel Stories",
+        "description": "Plan, organise, and remember your next adventure in five simple steps using the Travel Stories iPhone app.",
+        "totalTime": "PT10M",
+        "tool": [{ "@type": "HowToTool", "name": "Travel Stories iPhone app" }],
+        "step": howToSteps,
+        "image": ogImage,
+        "supply": [],
+      }
+    : null;
+
+const featuresNode =
+  isHome && home?.features?.cards?.length
+    ? {
+        "@type": "ItemList",
+        "@id": `${canonicalURL.href}#features`,
+        "name": home.features.title,
+        "itemListOrder": "https://schema.org/ItemListOrderAscending",
+        "numberOfItems": home.features.cards.length,
+        "itemListElement": home.features.cards.map((c, i) => ({
+          "@type": "ListItem",
+          "position": i + 1,
+          "name": c.title,
+          "description": c.subtitle,
+        })),
+      }
+    : null;
+
+const graph = [
+  orgNode,
+  personNode,
+  webSiteNode,
+  webPageNode,
+  breadcrumbNode,
+  ...(isHome ? [appNode] : []),
+  faqNode,
+  howToNode,
+  featuresNode,
+].filter(Boolean);
 ---
 
 <!doctype html>
@@ -162,199 +352,11 @@ const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
     <meta name="twitter:description" content={seo.description} />
     <meta name="twitter:image" content={ogImage} />
 
-    <!-- Structured Data - Mobile Application -->
+    <!-- Structured Data: one consolidated @graph (see frontmatter) -->
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
-      "@type": "MobileApplication",
-      "@id": appId,
-      "name": "Travel Stories - Trip Planner",
-      "alternateName": "Travel Stories",
-      "operatingSystem": `iOS ${minimumOs}+`,
-      "applicationCategory": "TravelApplication",
-      "applicationSubCategory": "Trip Planner",
-      "softwareVersion": appVersion,
-      "datePublished": "2026-01",
-      ...(lastUpdated ? { "dateModified": lastUpdated } : {}),
-      "inLanguage": "en",
-      "featureList": featureList,
-      "sameAs": [appStoreLink].filter(Boolean),
-      "offers": {
-        "@type": "Offer",
-        "price": appPrice,
-        "priceCurrency": "USD",
-        "availability": "https://schema.org/InStock",
-        "url": appStoreLink,
-        "eligibleRegion": { "@type": "Place", "name": "Worldwide" },
-        "seller": { "@id": orgId },
-        "description": "Free to download (1 trip included). Optional one-time Premium Lifetime in-app purchase ($1.99) unlocks unlimited trips, spending charts, calendar export, and sharing. No subscription."
-      },
-      ...(hasTrustedRating
-        ? {
-            "aggregateRating": {
-              "@type": "AggregateRating",
-              "ratingValue": String(appStore!.rating),
-              "ratingCount": String(appStore!.ratingCount),
-              "bestRating": "5",
-              "worstRating": "1",
-            },
-          }
-        : {}),
-      "description": seo.description,
-      "url": canonicalURL.href,
-      "downloadUrl": appStoreLink,
-      "installUrl": appStoreLink,
-      "screenshot": screenshotUrls,
-      "image": ogImage,
-      "author": { "@id": authorId },
-      "publisher": publisherRef
+      "@graph": graph,
     })} />
-
-    <!-- Structured Data - Author (Person) -->
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "Person",
-      "@id": authorId,
-      "name": "Robert Jensen",
-      "email": "robert@12f.dk",
-      "url": "https://www.12f.dk",
-      "jobTitle": "Founder & Developer",
-      "worksFor": publisherRef
-    })} />
-
-    <!-- Structured Data - Organization -->
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "Organization",
-      "@id": orgId,
-      "name": "12f.dk",
-      "url": "https://www.12f.dk",
-      "logo": {
-        "@type": "ImageObject",
-        "url": ogImage,
-        "caption": "12f.dk logo"
-      },
-      "image": ogImage,
-      "sameAs": orgSameAs,
-      "founder": { "@id": authorId },
-      "contactPoint": [
-        {
-          "@type": "ContactPoint",
-          "email": "robert@12f.dk",
-          "contactType": "customer support",
-          "availableLanguage": ["English"],
-          "url": Astro.site?.href,
-          "areaServed": "Worldwide"
-        }
-      ]
-    })} />
-
-    {isHome && faqEntities.length > 0 && (
-      <script type="application/ld+json" set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": faqEntities,
-        "speakable": {
-          "@type": "SpeakableSpecification",
-          "cssSelector": [".faq-item summary", ".faq-item summary + div"]
-        }
-      })} />
-    )}
-
-    {isHome && howToSteps.length > 0 && (
-      <script type="application/ld+json" set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "HowTo",
-        "name": "How to plan a trip with Travel Stories",
-        "description": "Plan, organise, and remember your next adventure in five simple steps using the Travel Stories iPhone app.",
-        "totalTime": "PT10M",
-        "tool": [{ "@type": "HowToTool", "name": "Travel Stories iPhone app" }],
-        "step": howToSteps,
-        "image": ogImage,
-        "supply": [],
-      })} />
-    )}
-
-    {isHome && home?.features?.cards?.length ? (
-      <script type="application/ld+json" set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "ItemList",
-        "name": home.features.title,
-        "itemListOrder": "https://schema.org/ItemListOrderAscending",
-        "numberOfItems": home.features.cards.length,
-        "itemListElement": home.features.cards.map((c, i) => ({
-          "@type": "ListItem",
-          "position": i + 1,
-          "name": c.title,
-          "description": c.subtitle,
-        })),
-      })} />
-    ) : null}
-
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "@id": `${Astro.site?.href}#breadcrumb`,
-      "itemListElement": [
-        {
-          "@type": "ListItem",
-          "position": 1,
-          "name": "Home",
-          "item": Astro.site?.href,
-        },
-        ...(isHome
-          ? []
-          : [{
-              "@type": "ListItem",
-              "position": 2,
-              "name": seo.title.split("|")[0].trim(),
-              "item": canonicalURL.href,
-            }]),
-      ],
-    })} />
-
-    <!-- Structured Data - Website -->
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "WebSite",
-      "@id": siteId,
-      "name": name,
-      "alternateName": "Travel Stories - Trip Planner",
-      "url": Astro.site?.href,
-      "description": seo.description,
-      "inLanguage": "en",
-      "publisher": publisherRef,
-      ...(isHome ? { "mainEntity": { "@id": appId } } : {})
-    })} />
-
-    {/* WebPage with speakable — lets voice assistants (Google Assistant,
-        Alexa via schema.org) read the hero headline, feature list, and FAQ
-        out loud. */}
-    {isHome && (
-      <script type="application/ld+json" set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "WebPage",
-        "@id": `${canonicalURL.href}#webpage`,
-        "url": canonicalURL.href,
-        "name": seo.title,
-        "description": seo.description,
-        "inLanguage": "en",
-        "isPartOf": { "@id": siteId },
-        "about": { "@id": appId },
-        "primaryImageOfPage": {
-          "@type": "ImageObject",
-          "url": ogImage
-        },
-        "speakable": {
-          "@type": "SpeakableSpecification",
-          "cssSelector": [
-            "#hero-headline",
-            "#features-heading + div + ul",
-            ".faq-item"
-          ]
-        },
-        "breadcrumb": { "@id": `${Astro.site?.href}#breadcrumb` }
-      })} />
-    )}
 
     <script is:inline define:vars={{ forceTheme, theme }}>
       const darkTheme = `${theme}-dark`;

--- a/src/components/blog/FaqSection.astro
+++ b/src/components/blog/FaqSection.astro
@@ -11,18 +11,8 @@ interface Props {
 
 const { items, heading = "Frequently asked questions" } = Astro.props;
 
-const schema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: items.map((item) => ({
-    "@type": "Question",
-    name: item.question,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: item.answer,
-    },
-  })),
-};
+// No JSON-LD here: the page folds an FAQPage node into its single
+// consolidated @graph (see BlogLayout extraGraphNodes, #24).
 ---
 
 {
@@ -41,7 +31,6 @@ const schema = {
           </details>
         ))}
       </div>
-      <script type="application/ld+json" set:html={JSON.stringify(schema)} />
     </section>
   )
 }

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,6 +11,8 @@ interface Props {
   ogImage?: string;
   canonicalPath?: string;
   articleSchema?: Record<string, unknown>;
+  /** Extra JSON-LD nodes merged into the page's single @graph (e.g. FAQPage). */
+  extraGraphNodes?: Record<string, unknown>[];
   publishedTime?: string;
   modifiedTime?: string;
   author?: string;
@@ -25,6 +27,7 @@ const {
   ogImage,
   canonicalPath,
   articleSchema,
+  extraGraphNodes = [],
   publishedTime,
   modifiedTime,
   author,
@@ -48,18 +51,27 @@ const resolvedOgImage = ogImage
   : new URL("/og-image.png", Astro.site).href;
 const siteUrl = Astro.site?.href ?? "https://travel-stories.12f.dk";
 
-const websiteSchema = {
-  "@context": "https://schema.org",
+// Same @ids as Layout.astro so the crawler's knowledge graph unifies the
+// blog pages with the homepage entities (#24).
+const orgId = "https://www.12f.dk/#organization";
+const siteId = `${siteUrl}#website`;
+const breadcrumbId = `${canonicalURL.href}#breadcrumb`;
+
+const websiteNode = {
   "@type": "WebSite",
+  "@id": siteId,
   name: config.name,
   url: siteUrl,
   description: config.seo.description,
   inLanguage: "en",
-  publisher: {
-    "@type": "Organization",
-    name: "12f.dk",
-    url: "https://www.12f.dk",
-  },
+  publisher: { "@id": orgId },
+};
+
+const orgNode = {
+  "@type": "Organization",
+  "@id": orgId,
+  name: "12f.dk",
+  url: "https://www.12f.dk",
 };
 
 const breadcrumbItems = [
@@ -84,11 +96,22 @@ if (Astro.url.pathname !== "/blog/" && Astro.url.pathname !== "/blog") {
     item: canonicalURL.href,
   });
 }
-const breadcrumbSchema = {
-  "@context": "https://schema.org",
+const breadcrumbNode = {
   "@type": "BreadcrumbList",
+  "@id": breadcrumbId,
   itemListElement: breadcrumbItems,
 };
+
+// Strip any @context the page passed on the article node — the graph has one.
+const articleNode = articleSchema
+  ? Object.fromEntries(
+      Object.entries(articleSchema).filter(([key]) => key !== "@context"),
+    )
+  : null;
+
+const graph = [orgNode, websiteNode, breadcrumbNode, articleNode, ...extraGraphNodes].filter(
+  Boolean,
+);
 ---
 
 <!doctype html>
@@ -147,9 +170,10 @@ const breadcrumbSchema = {
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={resolvedOgImage} />
 
-    <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
-    {articleSchema && <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />}
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": graph,
+    })} />
 
     <script is:inline define:vars={{ forceTheme: config.forceTheme, theme: config.theme }}>
       const darkTheme = `${theme}-dark`;

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -71,7 +71,24 @@ const articleSchema = {
     name: "Travel Stories Blog",
     url: new URL("/blog/", Astro.site).href,
   },
+  speakable: {
+    "@type": "SpeakableSpecification",
+    cssSelector: ["[data-speakable]", ".faq-answer"],
+  },
 };
+
+const faqNode =
+  post.data.faq.length > 0
+    ? {
+        "@type": "FAQPage",
+        "@id": `${canonicalURL.href}#faq`,
+        mainEntity: post.data.faq.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: { "@type": "Answer", text: item.answer },
+        })),
+      }
+    : null;
 ---
 
 <BlogLayout
@@ -80,6 +97,7 @@ const articleSchema = {
   ogImage={ogImage}
   canonicalPath={canonicalPath}
   articleSchema={articleSchema}
+  extraGraphNodes={faqNode ? [faqNode] : []}
   publishedTime={post.data.publishDate.toISOString()}
   modifiedTime={(post.data.updatedDate ?? post.data.publishDate).toISOString()}
   author={post.data.author}


### PR DESCRIPTION
Every page now emits exactly one `<script type="application/ld+json">` containing a consolidated `@graph` (event-stories pattern). Blog pages share the same `@id`s as the homepage so the knowledge graph unifies — the duplicate/conflicting WebSite node is gone. Speakable added to WebPage (home) and Article (posts). Details in commit message; verified per-page in built HTML. Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS