### PR TITLE
Tone down entrance animations: replace full-width side slides with fade-rise

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -25,8 +25,8 @@ function Footer() {
             <motion.a
               key={index}
               variants={{
-                hidden: { opacity: 0, x: "-100%" },
-                visible: { opacity: 1, x: 0 },
+                hidden: { opacity: 0, y: 12 },
+                visible: { opacity: 1, y: 0 },
               }}
               transition={{ delay: index * 0.25 }}
               className="text-xl font-bold block uppercase whitespace-nowrap link no-underline text-primary hover:text-primary/50 md:text-4xl"
@@ -41,8 +41,8 @@ function Footer() {
             {socials?.facebook && (
               <motion.a
                 variants={{
-                  hidden: { opacity: 0, x: "-100%" },
-                  visible: { opacity: 1, x: 0 },
+                  hidden: { opacity: 0, y: 12 },
+                  visible: { opacity: 1, y: 0 },
                 }}
                 transition={{ delay: 0.25 }}
                 className="w-8 h-8 hover:text-primary/50"
@@ -55,8 +55,8 @@ function Footer() {
             {socials?.instagram && (
               <motion.a
                 variants={{
-                  hidden: { opacity: 0, x: "-100%" },
-                  visible: { opacity: 1, x: 0 },
+                  hidden: { opacity: 0, y: 12 },
+                  visible: { opacity: 1, y: 0 },
                 }}
                 transition={{ delay: 0.5 }}
                 className="w-8 h-8 hover:text-primary/50"
@@ -69,8 +69,8 @@ function Footer() {
             {socials?.twitter && (
               <motion.a
                 variants={{
-                  hidden: { opacity: 0, x: "-100%" },
-                  visible: { opacity: 1, x: 0 },
+                  hidden: { opacity: 0, y: 12 },
+                  visible: { opacity: 1, y: 0 },
                 }}
                 transition={{ delay: 0.75 }}
                 className="w-8 h-8 hover:text-primary/50"

--- a/src/modules/home/_components/features/index.tsx
+++ b/src/modules/home/_components/features/index.tsx
@@ -47,10 +47,10 @@ function Features() {
           <motion.li
             key={index}
             variants={{
-              hidden: { x: "-100%", opacity: 0 },
-              visible: { x: 0, opacity: 1 },
+              hidden: { y: 16, opacity: 0 },
+              visible: { y: 0, opacity: 1 },
             }}
-            transition={{ delay: 0.25 + index * 0.25 }}
+            transition={{ duration: 0.5, delay: index * 0.08, ease: [0.16, 1, 0.3, 1] }}
             className={clsx(
               "shadow-md border-primary/10 border-2 card relative overflow-hidden group px-12 transition-all duration-300 hover:shadow-xl hover:-translate-y-1 hover:border-primary/30",
               {

--- a/src/modules/home/_components/header/index.tsx
+++ b/src/modules/home/_components/header/index.tsx
@@ -89,8 +89,8 @@ function Header() {
                 )}
               </motion.h1>
               <motion.p
-                initial={{ opacity: 0, x: -50 }}
-                animate={{ opacity: 1, x: 0 }}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.5, ease: "easeInOut" }}
                 className="whitespace-pre-wrap text-left m-0 my-1 max-w-md md:text-lg md:max-w-lg text-base-content"
               >


### PR DESCRIPTION
Feature cards, footer columns, and the hero subtitle no longer slide in from the side — they use the same subtle fade + small rise as the rest of the page, with a much shorter stagger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjDw1iY492nBreW2JVfGRS