### PR TITLE
Packing list generator: one indexable utility page that ranks on its own

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -86,6 +86,15 @@ export default defineConfig({
           item.priority = 1.0;
           item.changefreq = "weekly";
         }
+        // The packing list tool is the only surface here built to be found by
+        // people who don't know the app exists, so it outranks the blog.
+        if (item.url === `${SITE}/packing-list/`) {
+          item.priority = 0.8;
+          item.changefreq = "monthly";
+        } else if (item.url.startsWith(`${SITE}/packing-list/`)) {
+          item.priority = 0.7;
+          item.changefreq = "monthly";
+        }
         if (
           item.url.includes("privacy-policy") ||
           item.url.includes("terms-and-conditions") ||

--- a/src/components/stickyDownload/index.tsx
+++ b/src/components/stickyDownload/index.tsx
@@ -15,7 +15,7 @@ function StickyDownload() {
   return (
     <motion.div
       style={{ opacity, y }}
-      className="fixed inset-x-0 bottom-0 z-50 border-t border-base-300 bg-base-100/95 p-3 backdrop-blur-md md:hidden"
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-base-300 bg-base-100/95 p-3 backdrop-blur-md md:hidden print:hidden"
     >
       <a
         href={appStoreLink}

--- a/src/content/blog/how-to-plan-a-trip-step-by-step.md
+++ b/src/content/blog/how-to-plan-a-trip-step-by-step.md
@@ -122,7 +122,7 @@ Build the list from the itinerary, not from memory:
 - **Activities** decide the gear: hiking days need different shoes than museum days.
 - **Trip length** decides quantities — and whether you're doing laundry mid-trip.
 
-Write the list down and check items off as they go in the bag. A mental list fails exactly when you're rushed, which is always. For a complete item-by-item breakdown — clothing, toiletries, electronics, documents, and the things people forget most — use the [packing list for international travel](/blog/packing-list-for-international-travel/).
+Write the list down and check items off as they go in the bag. A mental list fails exactly when you're rushed, which is always. For a complete item-by-item breakdown — clothing, toiletries, electronics, documents, and the things people forget most — use the [packing list for international travel](/blog/packing-list-for-international-travel/). To skip the writing entirely, the [packing list generator](/packing-list/) produces a checklist for your trip type, length and climate that you can tick off, print, or download.
 
 ## Step 6: Gather your documents
 

--- a/src/content/blog/packing-list-for-international-travel.md
+++ b/src/content/blog/packing-list-for-international-travel.md
@@ -34,7 +34,7 @@ A complete packing list for international travel has five sections: documents, c
 
 International trips punish forgetfulness more than domestic ones. Forget a charger on a weekend trip and you buy one at a gas station. Forget your passport, prescription meds, or the right power adapter on an international trip and you may not board the plane, or you spend a day of your holiday hunting for a pharmacy that stocks your medication.
 
-This guide is built to be copied. Take the base list, apply one of the destination modifiers at the end, delete what doesn't apply, and you're done. If you want the full pre-departure routine beyond packing — house, money, phone plan — see the [travel checklist before leaving](/blog/travel-checklist-before-leaving/).
+This guide is built to be copied. Take the base list, apply one of the destination modifiers at the end, delete what doesn't apply, and you're done. If you'd rather have that done for you, the [packing list generator](/packing-list/) builds the same list from your trip type, length and climate — free, no sign-up, and printable. If you want the full pre-departure routine beyond packing — house, money, phone plan — see the [travel checklist before leaving](/blog/travel-checklist-before-leaving/).
 
 ## Documents: the section you check twice
 
@@ -124,6 +124,8 @@ Two notes. First, most modern chargers accept 100-240V, so you need an adapter (
 
 Don't write a new list per trip. Keep the base list and add one block.
 
+Each of these has a ready-made version with the base list already merged in: [beach](/packing-list/7-day-beach-trip-packing-list/), [city break](/packing-list/weekend-city-break-packing-list/), [cold weather](/packing-list/week-long-ski-trip-packing-list/), and [business](/packing-list/3-day-business-trip-packing-list/).
+
 **Beach:**
 - 2 swimsuits (one dries while you wear the other)
 - Flip-flops or sandals
@@ -183,3 +185,5 @@ Packing is also only one lane of trip prep. Booking order, budget, and the day-b
 ## Put it into practice
 
 Copy the base list, apply your destination modifier, and cut anything that fails the $10 test — then keep the list somewhere reusable, like the packing checklist in Travel Stories, so your next trip starts from a list that already works.
+
+Or skip the copying: the [packing list generator](/packing-list/) assembles the base list and the right modifiers from your trip type, length and climate, and gives you something you can tick off, print, or send to whoever you're travelling with.

--- a/src/content/blog/travel-checklist-before-leaving.md
+++ b/src/content/blog/travel-checklist-before-leaving.md
@@ -117,7 +117,7 @@ The middle wave: money, tech, and the home logistics that can't be done too earl
 **Packing**
 
 - Do laundry so everything on the packing list is actually clean and available
-- Finalize the packing list — the item-by-item version is in the [packing list for international travel](/blog/packing-list-for-international-travel/)
+- Finalize the packing list — the item-by-item version is in the [packing list for international travel](/blog/packing-list-for-international-travel/), or build one for your exact trip with the [packing list generator](/packing-list/)
 
 This is also the week to move your checklist off scraps of paper. Travel Stories keeps your checklist, packing list, documents, and itinerary together in one offline app — [free on the App Store](https://apps.apple.com/app/id6756801168) — so ticking items off this week is the same app you'll open at the airport.
 

--- a/src/data/packingList/generate.ts
+++ b/src/data/packingList/generate.ts
@@ -1,0 +1,171 @@
+import { RULES } from "./rules";
+import {
+  CATEGORY_IDS,
+  CATEGORY_TITLES,
+  CLIMATE_LABELS,
+  CLIMATES,
+  DEFAULT_OPTIONS,
+  TRIP_TYPE_LABELS,
+  TRIP_TYPES,
+  type Climate,
+  type PackingItem,
+  type PackingOptions,
+  type PackingSection,
+  type Rule,
+  type TripType,
+} from "./types";
+
+function matches(rule: Rule, o: PackingOptions): boolean {
+  const w = rule.when;
+  if (!w) return true;
+  if (w.types && !w.types.includes(o.type)) return false;
+  if (w.climates && !w.climates.includes(o.climate)) return false;
+  if (w.minDays !== undefined && o.days < w.minDays) return false;
+  if (w.maxDays !== undefined && o.days > w.maxDays) return false;
+  if (w.carryOnOnly !== undefined && w.carryOnOnly !== o.carryOnOnly) return false;
+  if (w.checkedBag !== undefined && w.checkedBag !== o.checkedBag) return false;
+  if (w.kids !== undefined && w.kids !== o.kids) return false;
+  return true;
+}
+
+/**
+ * Build the list for a set of options.
+ *
+ * Pure and deterministic — the same options always produce the same list, which
+ * is what lets a curated page pre-render its list at build time and the island
+ * re-derive the identical one after hydration.
+ *
+ * `extras` are appended last so a curated page can add destination-specific
+ * items without them being de-duplicated away by a generic rule of the same id.
+ */
+export function buildPackingList(
+  options: PackingOptions,
+  extras: readonly PackingItem[] = [],
+): PackingSection[] {
+  const seen = new Map<string, PackingItem>();
+  const byCategory = new Map<string, PackingItem[]>();
+
+  const add = (item: PackingItem, override = false) => {
+    const existing = seen.get(item.id);
+    if (existing) {
+      // First rule to claim an id wins, so the trip-type note beats the
+      // generic climate one. A curated page's own version overrides in place,
+      // keeping its position rather than appearing twice further down.
+      if (override) Object.assign(existing, item);
+      return;
+    }
+    seen.set(item.id, item);
+    const list = byCategory.get(item.category);
+    if (list) list.push(item);
+    else byCategory.set(item.category, [item]);
+  };
+
+  for (const rule of RULES) {
+    if (!matches(rule, options)) continue;
+    for (const spec of rule.items) {
+      const note = typeof spec.note === "function" ? spec.note(options) : spec.note;
+      add({
+        id: spec.id,
+        category: spec.category,
+        label: typeof spec.label === "function" ? spec.label(options) : spec.label,
+        ...(note ? { note } : {}),
+      });
+    }
+  }
+  for (const extra of extras) add({ ...extra }, true);
+
+  return CATEGORY_IDS.map((id) => ({
+    id,
+    title: CATEGORY_TITLES[id],
+    items: byCategory.get(id) ?? [],
+  })).filter((section) => section.items.length > 0);
+}
+
+export function countItems(sections: readonly PackingSection[]): number {
+  return sections.reduce((total, section) => total + section.items.length, 0);
+}
+
+/** Human summary of a configuration — used in headings, alt text and exports. */
+export function describeOptions(o: PackingOptions): string {
+  const parts = [
+    `${o.days}-day ${TRIP_TYPE_LABELS[o.type].toLowerCase()}`,
+    `${CLIMATE_LABELS[o.climate].toLowerCase()} weather`,
+  ];
+  if (o.carryOnOnly) parts.push("carry-on only");
+  else if (o.checkedBag) parts.push("with a checked bag");
+  if (o.kids) parts.push("travelling with kids");
+  return parts.join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// URL state. A configured list has to be shareable, so the options round-trip
+// through the query string: ?type=beach&days=7&climate=hot&carryon=1
+// ---------------------------------------------------------------------------
+
+export function optionsToQuery(o: PackingOptions): string {
+  const params = new URLSearchParams({
+    type: o.type,
+    days: String(o.days),
+    climate: o.climate,
+  });
+  if (o.carryOnOnly) params.set("carryon", "1");
+  if (o.checkedBag) params.set("checked", "1");
+  if (o.kids) params.set("kids", "1");
+  return params.toString();
+}
+
+const isTripType = (v: string | null): v is TripType =>
+  !!v && (TRIP_TYPES as readonly string[]).includes(v);
+const isClimate = (v: string | null): v is Climate =>
+  !!v && (CLIMATES as readonly string[]).includes(v);
+
+/** Anything unparseable falls back to `base` — a bad link still renders a list. */
+export function optionsFromQuery(
+  query: string | URLSearchParams,
+  base: PackingOptions = DEFAULT_OPTIONS,
+): PackingOptions {
+  const params =
+    typeof query === "string" ? new URLSearchParams(query) : query;
+
+  const rawDays = Number.parseInt(params.get("days") ?? "", 10);
+  const days = Number.isFinite(rawDays)
+    ? Math.min(Math.max(rawDays, 1), 60)
+    : base.days;
+
+  const flag = (key: string, fallback: boolean) => {
+    const value = params.get(key);
+    if (value === null) return fallback;
+    return value === "1" || value === "true";
+  };
+
+  const carryOnOnly = flag("carryon", base.carryOnOnly);
+  return {
+    type: isTripType(params.get("type")) ? (params.get("type") as TripType) : base.type,
+    days,
+    climate: isClimate(params.get("climate"))
+      ? (params.get("climate") as Climate)
+      : base.climate,
+    carryOnOnly,
+    // Carry-on only and a checked bag are contradictory; the former wins.
+    checkedBag: carryOnOnly ? false : flag("checked", base.checkedBag),
+    kids: flag("kids", base.kids),
+  };
+}
+
+/** Plain-text export, shared by the copy and download actions. */
+export function sectionsToText(
+  sections: readonly PackingSection[],
+  heading: string,
+): string {
+  const lines: string[] = [heading, "=".repeat(heading.length), ""];
+  for (const section of sections) {
+    lines.push(section.title.toUpperCase());
+    for (const item of section.items) {
+      // Middot, not an em dash: the notes contain em dashes of their own.
+      lines.push(`[ ] ${item.label}${item.note ? ` · ${item.note}` : ""}`);
+    }
+    lines.push("");
+  }
+  lines.push("Generated with Travel Stories — https://travel-stories.12f.dk/packing-list/");
+  return lines.join("\n");
+}

--- a/src/data/packingList/index.ts
+++ b/src/data/packingList/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./generate";
+// Note: ./pages is intentionally not re-exported. It holds the curated page
+// copy and is server-only — pulling it in here would drag every word of it
+// into the client island's bundle.

--- a/src/data/packingList/pages.ts
+++ b/src/data/packingList/pages.ts
@@ -1,0 +1,983 @@
+import type { PackingItem, PackingOptions } from "./types";
+
+/**
+ * The curated long-tail pages under /packing-list/.
+ *
+ * Deliberately hand-written and deliberately finite. The cartesian product of
+ * type × duration × climate is several hundred near-identical pages, which is
+ * exactly the doorway-page pattern Google demotes — so a combination only earns
+ * a page when it has advice a generic list genuinely does not contain.
+ *
+ * Server-only: nothing here is imported by the client island, so this file
+ * never reaches the browser bundle.
+ */
+
+export interface AdviceBlock {
+  heading: string;
+  body: string;
+}
+
+export interface CuratedPage {
+  slug: string;
+  /** <title>. Distinct from every other page, including the blog. */
+  title: string;
+  h1: string;
+  description: string;
+  /** One-paragraph answer, up top, before anything else. */
+  lede: string;
+  options: PackingOptions;
+  advice: AdviceBlock[];
+  /** Items unique to this scenario, appended after the generated ones. */
+  extras: PackingItem[];
+  /** Blog slugs to link to for depth. */
+  related: string[];
+}
+
+const p = (page: CuratedPage) => page;
+
+export const CURATED_PAGES: CuratedPage[] = [
+  // ------------------------------------------------- destination + season ---
+  p({
+    slug: "what-to-pack-for-japan-in-winter",
+    title: "What to Pack for Japan in Winter: The Complete List",
+    h1: "What to pack for Japan in winter",
+    description:
+      "A winter Japan packing list built around what actually catches visitors out: constant shoe removal, cash-only counters, brutal indoor heating, and tiny hotel rooms.",
+    lede: "Japan in winter is cold outside and genuinely hot inside, and you will take your shoes off several times a day. Pack thin layers you can shed, slip-on shoes, socks without holes, and more cash than feels normal.",
+    options: { type: "city", days: 10, climate: "cold", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Layers, not one big coat",
+        body: "Tokyo and Kyoto sit around 2–10°C in January, which sounds manageable — and it is. What catches people out is the other side: shops, trains, and restaurants are heated hard, often to 24°C or more. A single heavy parka means you spend the day carrying it. Three thin layers under a windproof shell lets you strip down at the door and stay comfortable in both worlds.",
+      },
+      {
+        heading: "Your shoes come off constantly",
+        body: "Temples, ryokan, many restaurants, some museums, and a fair number of shops and clinics all expect bare or socked feet. Lace-up boots turn that into a two-minute production every time. Bring shoes you can step out of, and bring socks you would be happy for a stranger to look at — this is the trip where the pair with the hole gets noticed.",
+      },
+      {
+        heading: "Cash is still king in a surprising number of places",
+        body: "Cards are widely accepted in cities, but small restaurants, temple entries, shrine charms, older ryokan and rural buses are frequently cash-only. Withdraw from a 7-Eleven or Japan Post ATM — those reliably accept foreign cards when bank ATMs sometimes don't. A coin purse stops matter more than it sounds: the ¥100 and ¥500 coins accumulate fast and are what vending machines and lockers want.",
+      },
+      {
+        heading: "Pack smaller than you think",
+        body: "Business hotel rooms are compact enough that a large suitcase may not open fully on the floor. Shinkansen oversized-luggage spaces need a free reservation in advance. If you're moving between cities, the takkyubin luggage-forwarding service will send your case hotel-to-hotel overnight for a modest fee — which means you travel with a day bag and your case meets you there.",
+      },
+    ],
+    extras: [
+      { id: "jp-slip-ons", category: "clothing", label: "Slip-on shoes", note: "You'll remove them at temples, ryokan, and plenty of restaurants." },
+      { id: "jp-socks", category: "clothing", label: "Socks you'd show a stranger", note: "Because you will, several times a day." },
+      { id: "jp-coin-purse", category: "documents", label: "Coin purse", note: "¥100 and ¥500 coins pile up fast and run the vending machines and lockers." },
+      { id: "jp-suica", category: "tech", label: "Suica or Pasmo added to Apple Wallet", note: "Set it up before you land; it covers trains, buses and most convenience stores." },
+      { id: "jp-handkerchief", category: "gear", label: "A small hand towel", note: "Public toilets are immaculate and very often have no dryer or paper towels." },
+      { id: "jp-rubbish-bag", category: "gear", label: "A bag for your own rubbish", note: "Street bins are rare; you carry your litter until you find one." },
+      { id: "hand-warmers", category: "gear", label: "Hand warmers", note: "Or buy hokkairo stick-on ones from any convenience store for pocket change." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-iceland-in-summer",
+    title: "What to Pack for Iceland in Summer: A Realistic List",
+    h1: "What to pack for Iceland in summer",
+    description:
+      "Icelandic summer means 10°C, sideways rain, and daylight at 2am. Here's the packing list for the weather Iceland actually has, not the one the photos suggest.",
+    lede: "Summer in Iceland averages 10–13°C with wind and rain that arrive without warning. Pack waterproof trousers as well as a jacket, an eye mask for the midnight sun, and swimwear you can reach easily.",
+    options: { type: "hiking", days: 7, climate: "mild", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Wind is the story, not cold",
+        body: "Ten degrees is fine. Ten degrees with a 20 m/s crosswind carrying rain horizontally is a different proposition, and it is a normal Tuesday. The single most useful item is a genuinely windproof, genuinely waterproof shell — and the item most people wish they'd brought is waterproof over-trousers. A jacket alone means arriving at a waterfall dry on top and soaked from the waist down.",
+      },
+      {
+        heading: "The midnight sun is not a metaphor",
+        body: "In June it never properly gets dark. Curtains in guesthouses are often thin, campervans have none worth the name, and your body will not volunteer to sleep at 11pm in broad daylight. An eye mask is a small item that decides whether the trip is restful. Earplugs help too if you're near a campsite or a road.",
+      },
+      {
+        heading: "Swimwear lives near the top of the bag",
+        body: "Geothermal pools are the national pastime and every town has one. Bring swimwear, flip-flops, and a quick-dry towel — and know that pool etiquette requires a thorough naked shower before you enter, in an open communal area. This is non-negotiable and enforced. Knowing it in advance is the difference between a good afternoon and an awkward one.",
+      },
+      {
+        heading: "Skip the cash, bring the sunglasses",
+        body: "Iceland is close to cashless — cards work at fuel pumps, toilets, and remote cafés, so exchanging money is largely wasted effort. Do bring sunglasses: the sun stays low even at midday, and low-angle glare off wet roads and glaciers is constant. And buy alcohol at the arrivals duty-free before you leave the airport, unless you enjoy paying triple.",
+      },
+    ],
+    extras: [
+      { id: "is-overtrousers", category: "clothing", label: "Waterproof over-trousers", note: "The item most people regret leaving at home." },
+      { id: "is-eyemask", category: "gear", label: "Eye mask", note: "It does not get dark in June, and curtains rarely help." },
+      { id: "is-swim", category: "clothing", label: "Swimwear and flip-flops", note: "Every town has a geothermal pool; a naked pre-shower is required and enforced." },
+      { id: "is-buff", category: "clothing", label: "Buff or neck gaiter", note: "Wind-driven rain finds the gap between collar and hood." },
+      { id: "is-carsick", category: "health", label: "Motion sickness tablets", note: "The Ring Road plus gravel side roads plus a boat tour is a lot of movement." },
+      { id: "is-dutyfree", category: "documents", label: "Duty-free plan for alcohol", note: "Buy on arrival at Keflavík; state-monopoly prices in town are roughly triple." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-thailand",
+    title: "What to Pack for Thailand: A Two-Week Backpacking List",
+    h1: "What to pack for Thailand",
+    description:
+      "A Thailand packing list that assumes you'll buy half of it there. Temple dress codes, the heat, the rain, and the things that are genuinely worth carrying from home.",
+    lede: "Pack light for Thailand — clothes, toiletries and most gear are cheap and everywhere. What's worth carrying from home is sunscreen, repellent you trust, and one outfit that covers shoulders and knees.",
+    options: { type: "backpacking", days: 14, climate: "tropical", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Temple dress code is enforced, not suggested",
+        body: "Shoulders and knees covered, for everyone. The Grand Palace in Bangkok is the strictest and turns away people daily; sarongs are sometimes available to rent at the gate, sometimes not. One pair of light long trousers and one shirt with sleeves solves it for the whole trip, and doubles as protection on the days the sun is unreasonable.",
+      },
+      {
+        heading: "Buy it there — with three exceptions",
+        body: "Clothing, flip-flops, toiletries, and a beach towel all cost less in any Thai 7-Eleven or market than the space they take in your bag. Three things are worth carrying: sunscreen (expensive locally and frequently mixed with skin-whitening agents), a repellent you already know works, and any medication you rely on. Thai pharmacies are excellent and cheap for everything else.",
+      },
+      {
+        heading: "Rain is a daily event, not a ruined day",
+        body: "In the wet season, expect a heavy downpour most afternoons that clears within the hour. That calls for a light rain shell and dry bags for electronics — not for cancelling plans. If you're taking ferries between islands, bags get loaded on open decks: a waterproof cover or a liner bag inside your pack is the difference between damp and destroyed.",
+      },
+      {
+        heading: "Feet and scooters",
+        body: "You'll be in sandals almost permanently, which is fine until a long temple day; one pair of closed shoes earns its place. If you plan to ride a scooter, wear a helmet that actually fastens and cover your legs — road rash from a low-speed slide on hot tarmac is the single most common injury travellers bring home from Thailand, and travel insurance often refuses claims without the correct licence.",
+      },
+    ],
+    extras: [
+      { id: "th-modest", category: "clothing", label: "Light long trousers and a sleeved shirt", note: "Temple dress code, enforced at the door." },
+      { id: "th-sunscreen", category: "toiletries", label: "Sunscreen brought from home", note: "Local versions are pricey and often contain whitening agents." },
+      { id: "th-drybag", category: "gear", label: "Dry bag or pack liner", note: "Ferry bags ride on open decks in the rain." },
+      { id: "th-closed-shoes", category: "clothing", label: "One pair of closed shoes", note: "For long temple days and anywhere with steps." },
+      { id: "th-insurance-licence", category: "documents", label: "Motorcycle licence, if you plan to ride", note: "Insurers routinely reject scooter claims without one." },
+      { id: "th-power", category: "tech", label: "Type A/B/C adapter", note: "Thai sockets take all three; a universal adapter is fine." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-italy-in-summer",
+    title: "What to Pack for Italy in Summer: Cities, Churches & Heat",
+    h1: "What to pack for Italy in summer",
+    description:
+      "An Italian summer packing list built around three realities: church dress codes, cobblestones, and 35°C afternoons. Includes what to wear and what to leave home.",
+    lede: "Italy in summer means heat, cobblestones and dress codes. Pack a light scarf or shawl for churches, shoes with real soles, and a refillable bottle — the public fountains are drinkable and everywhere.",
+    options: { type: "city", days: 7, climate: "hot", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Churches turn people away every day",
+        body: "St Peter's Basilica, the Duomo in Florence, and hundreds of smaller churches require covered shoulders and knees, and they employ people at the door specifically to enforce it. In 35°C heat you will not want to dress for it all day — so carry a light scarf or linen shawl in your bag and a pair of trousers or a longer skirt for any day with a cathedral on it. It weighs nothing and saves the queue you already stood in.",
+      },
+      {
+        heading: "The cobblestones are the real terrain",
+        body: "Rome's sampietrini, Florence's flagstones, and Venice's bridges are unforgiving. Thin-soled fashion sneakers leave your feet aching by day three, and cheap suitcase wheels genuinely break. Pack shoes with a proper sole and, if you're moving between cities, a bag you're willing to carry up a staircase rather than drag.",
+      },
+      {
+        heading: "Water is free; the fountains are safe",
+        body: "Rome's nasoni run continuously with cold, drinkable water, and most Italian cities have equivalents. A refillable bottle saves several euros a day and a lot of plastic. Restaurants charge for bottled water and it is normal to be asked whether you want it — 'acqua del rubinetto' is tap and is fine.",
+      },
+      {
+        heading: "August is quieter than you expect, in the wrong way",
+        body: "Mid-August is when Italians take their own holidays. Cities empty, but so do the good restaurants and small shops — many close for two or three weeks. If you're going then, plan around it, and expect the heat to peak. Dress a shade smarter than you would at home: Italy notices, and the difference between beachwear and city clothes matters inland.",
+      },
+    ],
+    extras: [
+      { id: "it-shawl", category: "clothing", label: "Light scarf or linen shawl", note: "Covers shoulders at church doors; weighs nothing in a day bag." },
+      { id: "it-soles", category: "clothing", label: "Shoes with a proper sole", note: "Cobblestones punish thin-soled sneakers by day three." },
+      { id: "it-bottle", category: "gear", label: "Refillable bottle", note: "Rome's nasoni fountains run cold, free and drinkable all day." },
+      { id: "it-crossbody", category: "gear", label: "Crossbody bag that zips", note: "Pickpockets work the same three streets in every Italian city." },
+      { id: "it-mosquito", category: "health", label: "Mosquito repellent", note: "Venice and Florence at dusk in August are worse than most people expect." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-a-safari",
+    title: "What to Pack for a Safari: Colours, Weight Limits & Dust",
+    h1: "What to pack for a safari",
+    description:
+      "A safari packing list covering the two rules that catch people out: which colours to avoid and why, and the strict soft-bag weight limits on light aircraft transfers.",
+    lede: "Safari packing has two hard rules: neutral colours only — no blue or black, no camouflage — and a soft-sided bag, because light aircraft transfers cap luggage at around 15kg with no hard cases allowed.",
+    options: { type: "hiking", days: 7, climate: "hot", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Colour is a practical rule, not a dress code",
+        body: "Khaki, olive, beige and brown. Avoid dark blue and black — tsetse flies are drawn to them and their bite is memorable. Avoid white, which shows the dust within an hour. And avoid camouflage entirely: it is illegal for civilians in several African countries, including Zimbabwe, Zambia and Botswana, and confiscation at the airport does happen.",
+      },
+      {
+        heading: "The weight limit is real and the bag shape matters",
+        body: "Light aircraft transfers between camps typically allow 15kg total, including hand luggage, in a soft-sided duffel — hard-shell suitcases will not fit in the hold and get refused. Weigh your bag at home. Most camps include daily laundry, so pack three or four days of clothes for a week and stop worrying about it.",
+      },
+      {
+        heading: "Dawn drives are genuinely cold",
+        body: "A game drive leaves before sunrise in an open vehicle at speed. Even in a hot climate, that is a fleece-and-beanie proposition for the first two hours, after which you'll be in a t-shirt by ten. Layers you can peel off and stuff in a bag are the entire wardrobe strategy. A blanket is usually provided; a windproof layer is usually not.",
+      },
+      {
+        heading: "Dust, optics and power",
+        body: "Dust gets into everything, cameras first — a dry bag or a sealed pouch for lenses is worth its space. Bring binoculars per person rather than one pair to share, because the moment does not wait. Camp power is often generator or solar with limited hours, so a power bank matters more than a wall charger. Leave the drone at home: they are banned in most national parks and the fines are not small.",
+      },
+    ],
+    extras: [
+      { id: "sf-neutrals", category: "clothing", label: "Neutral clothing — khaki, olive, beige", note: "No dark blue or black (tsetse flies), no white (dust), no camouflage (illegal in several countries)." },
+      { id: "sf-duffel", category: "gear", label: "Soft-sided duffel, under 15kg", note: "Light aircraft transfers refuse hard cases and enforce the weight." },
+      { id: "sf-fleece", category: "clothing", label: "Fleece and beanie for dawn drives", note: "Open vehicle, before sunrise, at speed. It's cold." },
+      { id: "sf-binoculars", category: "gear", label: "Binoculars, one pair per person", note: "Sharing means missing it." },
+      { id: "sf-camera-dust", category: "tech", label: "Sealed pouch for camera and lenses", note: "Dust is the main cause of safari camera failure." },
+      { id: "sf-malaria", category: "health", label: "Malaria prophylaxis and a prescription copy", note: "Start the course before you travel, per your doctor's schedule." },
+      { id: "sf-torch", category: "gear", label: "Head torch", note: "Camps power down at night and paths between tents are unlit." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-new-york-in-winter",
+    title: "What to Pack for New York in Winter: A 4-Day List",
+    h1: "What to pack for New York in winter",
+    description:
+      "A winter New York packing list for a long weekend: wind tunnels, slush at every crossing, overheated interiors, and the fact that you'll be carrying your coat indoors.",
+    lede: "New York in winter is a walking city with wind funnelled between towers and slush at every kerb. Pack waterproof boots with grip, a hat that covers your ears, and layers you can strip off the moment you step inside.",
+    options: { type: "city", days: 4, climate: "cold", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "You will walk further than you plan to",
+        body: "Twenty blocks looks like nothing on a map and takes twenty minutes on foot, and you'll do that several times a day. Whatever you'd normally consider a comfortable shoe needs to be one step more comfortable — and waterproof. Kerbside slush pools are ankle-deep at crossings for days after snow, and fashion boots with smooth soles are genuinely hazardous on the polished-marble lobby floors that follow.",
+      },
+      {
+        heading: "The wind between buildings is the coldest part",
+        body: "Avenues run north–south and funnel wind straight down them; the temperature on your face on Sixth Avenue bears little relation to the forecast. A hat that covers your ears and a scarf you can pull up over your chin do more than a heavier coat. Gloves you can use a touchscreen through save you taking them off forty times a day.",
+      },
+      {
+        heading: "Indoors is 24°C and you're carrying the coat",
+        body: "Restaurants, subway cars, museums and shops are heated hard. Every layer you wear must be one you're happy to be seen in, and you need somewhere to put the coat — a bag with a bit of give, or a coat you don't mind draping over a chair back. This is the main argument for two mid layers instead of one enormous parka.",
+      },
+      {
+        heading: "Pack lighter than usual, deliberately",
+        body: "Anything you forget is available within a ten-minute walk, at any hour. That makes New York the wrong city to pack contingencies for. Bring a smart-casual outfit if you have a restaurant or a show booked — plenty of places still care — and leave the rest of the 'just in case' pile at home.",
+      },
+    ],
+    extras: [
+      { id: "winter-boots", category: "clothing", label: "Waterproof boots with grip", note: "Kerbside slush is ankle-deep for days, and lobby floors are polished stone." },
+      { id: "ny-earhat", category: "clothing", label: "A hat that covers your ears", note: "The avenues funnel wind straight at you." },
+      { id: "ny-touch-gloves", category: "clothing", label: "Touchscreen gloves", note: "You'll be checking directions constantly." },
+      { id: "ny-smart-outfit", category: "clothing", label: "One smart-casual outfit", note: "Enough restaurants and theatres still have a dress code." },
+      { id: "ny-metro-card", category: "documents", label: "A contactless card for OMNY", note: "Tap straight in at the turnstile; no ticket machine queue." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-bali",
+    title: "What to Pack for Bali: A 10-Day List",
+    h1: "What to pack for Bali",
+    description:
+      "A Bali packing list covering temple sarongs, reef-safe sunscreen, scooter safety, and why laundry at a dollar a kilo means you should pack for four days, not ten.",
+    lede: "Pack four days of clothes for ten days in Bali — laundry costs about a dollar a kilo and comes back the next morning. What's worth carrying is a sarong, reef-safe sunscreen, and a stomach kit you trust.",
+    options: { type: "beach", days: 10, climate: "tropical", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "A sarong is the single most useful item",
+        body: "Temples require a sarong and sash for everyone, regardless of what else you're wearing. Larger sites lend them, smaller ones don't, and the lent ones have been worn by a lot of people in a humid climate. Buying your own for a few dollars on day one means you can visit anything on impulse — and it doubles as a beach towel, a shoulder cover, and a shade for a bus window.",
+      },
+      {
+        heading: "Pack for four days, not ten",
+        body: "Laundry services are everywhere at roughly a dollar a kilo, usually returned within 24 hours. Packing a full ten days of clothes into a humid climate means carrying a heavier bag so you can wear damp clothes. Bring quick-dry fabrics, expect nothing cotton to fully dry, and accept the wash.",
+      },
+      {
+        heading: "Scooters are how Bali moves, and how people get hurt",
+        body: "If you're going to ride, wear a helmet that fastens, cover your legs, and check your travel insurance covers you — most policies require a licence valid for the engine size, and most claims that get refused are scooter claims. Long trousers and closed shoes on a scooter is not caution, it's the difference between a wobble and a skin graft.",
+      },
+      {
+        heading: "The stomach kit and the sunscreen",
+        body: "Bring rehydration sachets, an anti-diarrheal, and the confidence to use them, because a couple of rough days is common enough to have a nickname. Drink bottled or filtered water and skip ice only where the place looks improvised. Sunscreen is expensive locally and reef-safe versions are scarce — several Indonesian dive sites now ask for it, so bring your own.",
+      },
+    ],
+    extras: [
+      { id: "bl-sarong", category: "clothing", label: "Your own sarong and sash", note: "Required at every temple; the lent ones are much-used in a humid climate." },
+      { id: "bl-reef-safe", category: "toiletries", label: "Reef-safe sunscreen from home", note: "Expensive and hard to find locally." },
+      { id: "bl-scooter-kit", category: "clothing", label: "Long trousers and closed shoes for riding", note: "Road rash is the most common travel injury here." },
+      { id: "bl-rehydration", category: "health", label: "Rehydration sachets and anti-diarrheal", note: "Common enough that locals have a name for it." },
+      { id: "bl-repellent", category: "health", label: "DEET or picaridin repellent", note: "Dengue is present year-round." },
+      { id: "bl-cash", category: "documents", label: "Rupiah in cash", note: "Warungs, temple donations and small drivers are cash-only." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-a-cruise",
+    title: "What to Pack for a Cruise: Cabin Storage, Dress Codes & Ports",
+    h1: "What to pack for a cruise",
+    description:
+      "A cruise packing list built around the cabin: vertical storage on magnetic steel walls, scarce outlets, banned surge protectors, and the bag that arrives four hours after you do.",
+    lede: "A cruise cabin is small, its walls are magnetic steel, and its power outlets are few. Pack magnetic hooks, a non-surge USB charger, and a carry-on with your swimwear — your main bag may not arrive for hours.",
+    options: { type: "beach", days: 7, climate: "hot", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Storage goes up, because the floor is taken",
+        body: "Cabin walls and doors are steel, so magnetic hooks turn blank vertical surfaces into storage for hats, lanyards, and wet swimwear. An over-the-door shoe organiser holds the entire contents of a bathroom shelf that doesn't exist. Suitcases usually slide under the bed, which is the only reason a hard case is manageable at all.",
+      },
+      {
+        heading: "Power is the most-confiscated category",
+        body: "Almost every cruise line bans surge-protected extension leads outright, as a fire risk, and security screens for them at embarkation. What is permitted is a simple non-surge USB charging cube or a cruise-approved multi-port block. Bring one, plus longer cables than usual, because outlets are frequently on the far side of the desk from the bed.",
+      },
+      {
+        heading: "Your bag arrives hours after you do",
+        body: "You board, the cabin may not be ready, and checked luggage is delivered to the door any time up to dinner. Put swimwear, sunscreen, medication and anything you need for the first afternoon in a small carry-on you keep with you. The alternative is watching the pool from a deck chair in the clothes you travelled in.",
+      },
+      {
+        heading: "Dress codes and shore days",
+        body: "Most lines run one or two 'formal' or 'elegant' evenings per week; the standard is a jacket or a cocktail dress rather than black tie, but turning up in shorts means dining elsewhere. For ports, pack a small day bag, small-denomination cash for local vendors and tips, and remember your ship card and passport requirements differ per port — check before each stop rather than assuming.",
+      },
+    ],
+    extras: [
+      { id: "cr-magnets", category: "gear", label: "Magnetic hooks", note: "Cabin walls are steel; this is where your vertical storage comes from." },
+      { id: "cr-charger", category: "tech", label: "Non-surge USB charging cube", note: "Surge-protected extension leads are banned and confiscated at embarkation." },
+      { id: "cr-day-one-bag", category: "gear", label: "Day-one carry-on with swimwear and meds", note: "Checked bags can arrive at the cabin hours later." },
+      { id: "cr-formal", category: "clothing", label: "One formal-night outfit", note: "Jacket or cocktail dress; shorts get you sent to the buffet." },
+      { id: "cr-lanyard", category: "gear", label: "Lanyard for your ship card", note: "It's your room key, your wallet and your boarding pass at every port." },
+      { id: "cr-seasickness", category: "health", label: "Motion sickness tablets or bands", note: "Take them before you feel it, not after." },
+      { id: "cr-small-bills", category: "documents", label: "Small-denomination cash", note: "For port taxis, tips and market stalls." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "what-to-pack-for-vietnam",
+    title: "What to Pack for Vietnam: North to South in Two Weeks",
+    h1: "What to pack for Vietnam",
+    description:
+      "Vietnam runs 1,600km north to south and Hanoi in winter is genuinely cold. A packing list for a two-week trip that crosses climates, sleeper buses and tailors.",
+    lede: "Vietnam is two climates in one country: Hanoi in January needs a proper jacket while Saigon never drops below warm. Pack layers, a rain poncho rather than an umbrella, and leave space in the bag for Hoi An.",
+    options: { type: "backpacking", days: 14, climate: "tropical", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "The north is not the south",
+        body: "Most Vietnam packing lists assume tropical heat throughout, and travellers arrive in Hanoi in January in shorts. Northern winters run 10–15°C with damp grey drizzle and buildings that have no heating, which feels colder than the number suggests. If your route covers the whole country, pack a warm layer and a rain shell for the north and accept that they'll be dead weight in the Mekong Delta.",
+      },
+      {
+        heading: "A poncho beats an umbrella",
+        body: "Rain in Vietnam frequently arrives while you're on the back of a scooter or a motorbike taxi, and an umbrella is useless there. The cheap plastic poncho sold on every street corner is what locals use — it covers you and the bag on your back. Buy one there rather than carrying one.",
+      },
+      {
+        heading: "Sleeper buses and overnight trains have their own kit",
+        body: "Overnight transport is how most people cover the distance, and the berths are short, the lights stay on, and bags travel below or beside you. An eye mask, earplugs and a small padlock make it survivable. Slip-on shoes matter here too — shoes come off on sleeper buses and at most family homestays.",
+      },
+      {
+        heading: "Leave room for what you'll have made",
+        body: "Hoi An's tailors will make clothing to measure in 24–48 hours at prices that make it worth planning around. If that's on your itinerary, arrive with space in the bag or an empty foldable duffel. Bring a photo of what you want — describing a garment across a language gap goes better with a picture.",
+      },
+    ],
+    extras: [
+      { id: "vn-warm-layer", category: "clothing", label: "A warm layer for the north", note: "Hanoi in winter is 10–15°C and buildings are unheated." },
+      { id: "vn-poncho", category: "clothing", label: "Rain poncho", note: "Works on the back of a scooter, which an umbrella does not." },
+      { id: "vn-slip-ons", category: "clothing", label: "Slip-on shoes", note: "Off at homestays, temples and on sleeper buses." },
+      { id: "vn-mask", category: "health", label: "A face mask for traffic", note: "Hanoi and Saigon air quality regularly hits unhealthy levels." },
+      { id: "vn-foldable-duffel", category: "gear", label: "Foldable duffel", note: "For the Hoi An tailoring you didn't plan to buy." },
+      { id: "vn-cash", category: "documents", label: "Small dong notes", note: "Rural buses, markets and street food are cash-only." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  // ----------------------------------------------------- duration + type ---
+  p({
+    slug: "7-day-beach-trip-packing-list",
+    title: "7-Day Beach Trip Packing List (With Quantities)",
+    h1: "7-day beach trip packing list",
+    description:
+      "A week at the beach, itemised with real quantities: two swimsuits, five outfits, and how much sunscreen a week actually takes. Print it or check it off online.",
+    lede: "A week at the beach needs less than you think, in the right combinations: two swimsuits so one is always dry, five outfits rather than seven, and considerably more sunscreen than one bottle.",
+    options: { type: "beach", days: 7, climate: "hot", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Two swimsuits is the rule that matters",
+        body: "One dries while you wear the other. Pulling on a cold, damp swimsuit at nine in the morning is the small daily misery that a second one removes for almost no weight. If you're swimming twice a day, make it three.",
+      },
+      {
+        heading: "You will wear less than you pack",
+        body: "Beach days are swimwear and a cover-up. The clothes only matter in the evening, which means five outfits covers a week with room to repeat. The category people genuinely under-pack is the evening layer: air conditioning indoors and a sea breeze after sunset make a light long-sleeve the most-worn item of the trip.",
+      },
+      {
+        heading: "How much sunscreen a week actually needs",
+        body: "A full-body application for one adult is roughly 30–35ml — about a shot glass. Applied twice a day for seven days, that's around 500ml per person, and most travel bottles hold 100ml. Buy the big bottle and decant, or plan to buy more at the destination and accept resort pricing. Running out on day four is the most common way a beach holiday turns painful.",
+      },
+      {
+        heading: "Sand gets into everything",
+        body: "A zip pouch for phone, cards and keys keeps sand out of charging ports, which is the failure mode that ends holidays for electronics. A quick-dry towel packs smaller than a hotel towel and, unlike the hotel's, is allowed to leave the property.",
+      },
+    ],
+    extras: [
+      { id: "b7-sunscreen-volume", category: "toiletries", label: "About 500ml of sunscreen per person", note: "35ml per full application, twice a day, seven days." },
+      { id: "b7-evening-layer", category: "clothing", label: "A light long-sleeve for evenings", note: "Air conditioning and the after-dark breeze; the most-worn item of the week." },
+      { id: "b7-zip-pouch", category: "gear", label: "Zip pouch for phone and cards", note: "Sand in a charging port is how beach holidays kill electronics." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "weekend-city-break-packing-list",
+    title: "Weekend City Break Packing List: One Bag, Two Nights",
+    h1: "Weekend city break packing list",
+    description:
+      "A two-night city break packed into one cabin bag. What a 48-hour wardrobe actually looks like, and why checking a bag costs you a quarter of the trip.",
+    lede: "A two-night city break fits in one cabin bag, and should: checking luggage costs you roughly an hour at each end, which is a real fraction of a 48-hour trip.",
+    options: { type: "city", days: 3, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "The maths argues for one bag",
+        body: "Bag drop at departure and the carousel on arrival cost somewhere between forty minutes and an hour and a half, each way. On a two-week holiday that's noise. On a 48-hour weekend it's a meal, a museum, or the difference between arriving in time for dinner and arriving in time for bed.",
+      },
+      {
+        heading: "A 48-hour wardrobe is three tops and two bottoms",
+        body: "Wear one set, pack the rest. One pair of shoes on your feet, and only add a second if a specific booking demands it. The bulkiest jacket goes on your body through the airport. That leaves the bag mostly empty, which is exactly the margin you want for whatever you buy while you're there.",
+      },
+      {
+        heading: "The shoes decide the weekend",
+        body: "A city break is a walking holiday that doesn't announce itself as one — 20,000 steps a day is normal. Whatever you wear needs to already be broken in. Blister plasters packed in advance cost nothing; finding a pharmacy in an unfamiliar city on a Sunday costs an afternoon.",
+      },
+      {
+        heading: "Check the bag policy before the museum, not at it",
+        body: "A surprising number of major museums and galleries refuse backpacks of any size and make you queue for a cloakroom. A crossbody or tote goes straight through. If your itinerary is museum-heavy, the day bag you choose is worth thirty seconds of thought.",
+      },
+    ],
+    extras: [
+      { id: "wc-crossbody", category: "gear", label: "Crossbody bag rather than a backpack", note: "Many museums refuse backpacks and send you to a cloakroom queue." },
+      { id: "wc-charge-night-before", category: "tech", label: "Everything charged the night before", note: "Two days is short enough to skip the chargers entirely if you're disciplined." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  p({
+    slug: "3-day-business-trip-packing-list",
+    title: "3-Day Business Trip Packing List (Carry-On Only)",
+    h1: "3-day business trip packing list",
+    description:
+      "Three days of meetings in one cabin bag: one suit worn twice, two shirts, and the reason your presentation needs to exist in two places that aren't the cloud.",
+    lede: "Three days of meetings fits in a cabin bag: one suit worn throughout, two or three shirts, and a comfortable pair of shoes for everything that isn't the meeting itself.",
+    options: { type: "business", days: 3, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "Carry-on only is a risk decision, not a convenience one",
+        body: "A delayed checked bag on a leisure trip is annoying. On a business trip it means presenting in the clothes you flew in. Three days of business wear genuinely fits in a cabin bag, and the certainty is worth more than the extra space.",
+      },
+      {
+        heading: "One suit, worn repeatedly, hung properly",
+        body: "Nobody is auditing whether the jacket is the same one. Two or three shirts rotate underneath it. Hang the suit in the bathroom during your first shower and most travel creases fall out in ten minutes — faster and safer than the hotel iron, which will find the one synthetic thing you own.",
+      },
+      {
+        heading: "Two pairs of shoes, and the second is for walking",
+        body: "Dress shoes for the meeting, something comfortable for the airport, the evening, and the twenty minutes between the hotel and the office. Wear the heavier pair on the plane. This is one of the few packing decisions where the second item genuinely earns its space.",
+      },
+      {
+        heading: "Your presentation needs to survive the conference Wi-Fi",
+        body: "Cloud storage is not a backup when the venue's network fails at 8:55am. Carry the deck on a USB stick and keep a copy on the laptop itself, not just synced. Bring the adapters for whatever the room might have — HDMI and USB-C at minimum. And put a spare shirt in the laptop bag: the coffee incident happens on the way to the meeting, never after it.",
+      },
+    ],
+    extras: [
+      { id: "bt-usb-deck", category: "tech", label: "Presentation on a USB stick and stored locally", note: "Cloud-only is not a backup when the venue Wi-Fi fails." },
+      { id: "bt-adapters", category: "tech", label: "HDMI and USB-C display adapters", note: "Assume the meeting room has neither of the ports your laptop has." },
+      { id: "bt-spare-shirt", category: "clothing", label: "A spare shirt in the laptop bag", note: "The coffee incident always happens on the way there." },
+      { id: "bt-steam", category: "toiletries", label: "The bathroom-steam trick instead of an iron", note: "Hang the suit during your first shower; creases drop in ten minutes." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  p({
+    slug: "weekend-hiking-packing-list",
+    title: "Weekend Hiking Packing List: Two Days, One Pack",
+    h1: "Weekend hiking packing list",
+    description:
+      "A two-day hiking list organised by weight: the big three that dominate your pack, the layering system that works, and the items you carry precisely because you hope not to use them.",
+    lede: "On a weekend hike you carry everything, so pack by weight rather than by category. Your pack, sleep system and shelter decide the load; everything else is grams around the edges.",
+    options: { type: "hiking", days: 2, climate: "mild", carryOnOnly: false, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "The big three decide your weekend",
+        body: "Pack, sleep system and shelter typically account for more than half your carried weight. Trimming 200g off your toiletries while carrying a four-kilo tent is optimising the wrong end. If you're borrowing or buying anything, that's where the decision matters — and where it's worth going out for a night close to home before committing to a real route.",
+      },
+      {
+        heading: "Layering, and never cotton",
+        body: "Base layer to move moisture, mid layer to hold warmth, shell to stop wind and rain. Cotton absorbs sweat, stays wet, and then actively cools you — which is a comfort problem on a warm day and a genuine safety problem on a cold one. Merino or synthetic throughout, including socks and underwear.",
+      },
+      {
+        heading: "Plan food per meal, not as 'snacks'",
+        body: "Two days is four or five eating occasions. Name each one and pack for it, and you'll carry the right amount instead of the vague amount. Add one emergency ration that stays in the bag no matter what — the day that runs long is exactly the day you've eaten everything.",
+      },
+      {
+        heading: "Carry the things you hope to waste",
+        body: "A head torch on a day hike, a first-aid kit you don't open, a whistle, a fully charged phone with offline maps, and a note of your route left with someone at home. These are the items whose value is entirely in the scenario where the walk goes wrong — which is why they get cut first and matter most.",
+      },
+    ],
+    extras: [
+      { id: "wh-sleep-system", category: "gear", label: "Sleeping bag and mat rated for the night, not the day", note: "Ground conducts heat away faster than air; the mat's R-value matters as much as the bag." },
+      { id: "wh-stove", category: "gear", label: "Stove, fuel and a lighter", note: "Plus a backup ignition source that isn't the same lighter." },
+      { id: "wh-emergency-ration", category: "gear", label: "One emergency ration you don't plan to eat", note: "For the day the walk runs three hours long." },
+      { id: "wh-route-note", category: "documents", label: "Your route, left with someone at home", note: "With the time you expect to be back." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "two-week-europe-packing-list",
+    title: "Two-Week Europe Packing List for Multiple Cities",
+    h1: "Two-week Europe packing list",
+    description:
+      "A multi-city Europe list built around the bag you carry up a fourth-floor walk-up: one laundry stop, three plug types, and 15°C of variation between north and south.",
+    lede: "For two weeks across several European cities, pack one week of clothes and plan a laundry stop. The binding constraint isn't the wardrobe — it's the bag you'll carry up a fourth-floor walk-up with no lift.",
+    options: { type: "city", days: 14, climate: "mild", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "The bag moves, so choose it for the stairs",
+        body: "A multi-city trip means your luggage gets lifted onto train racks, dragged over cobblestones, and carried up the staircase of an apartment whose listing did not mention the lift. A bag you can carry for ten minutes beats a bag you can only wheel. This is the single decision that shapes the whole trip.",
+      },
+      {
+        heading: "One wash, not two wardrobes",
+        body: "Seven days of clothes plus one laundry stop covers fourteen. Almost every European city has self-service laundrettes, and most apartment rentals have a machine. Budget two hours in the middle of the trip on a day you'd have spent walking anyway, and carry half the weight for the entire fortnight.",
+      },
+      {
+        heading: "Three plug types, not one",
+        body: "Type C two-pin covers most of the continent, but the UK and Ireland use Type G and Switzerland uses Type J, which the standard European plug does not fit. If your route crosses those borders, a universal adapter or a second plug is the difference between a charged phone and a hunt for a shop.",
+      },
+      {
+        heading: "North to south is a 15-degree swing",
+        body: "Stockholm and Seville in the same fortnight is a real range, and the shoulder seasons make it wider. Pack a layering system rather than a season: t-shirts, a mid layer, and a light rain jacket handles almost everything, with a scarf that covers church shoulders and cold train carriages equally.",
+      },
+    ],
+    extras: [
+      { id: "eu-carryable-bag", category: "gear", label: "A bag you can carry, not just wheel", note: "Fourth-floor walk-ups and cobbled streets are the norm, not the exception." },
+      { id: "eu-adapters", category: "tech", label: "Adapters for Type C, G and J", note: "The standard European plug does not fit UK, Irish or Swiss sockets." },
+      { id: "eu-laundry-stop", category: "clothing", label: "A laundry stop pencilled into the itinerary", note: "Two hours mid-trip halves the weight you carry for the other thirteen days." },
+      { id: "eu-scarf", category: "clothing", label: "A scarf", note: "Church shoulders, cold trains, and the plane. Earns its space three ways." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "10-day-backpacking-packing-list",
+    title: "10-Day Backpacking Packing List Under 10kg",
+    h1: "10-day backpacking packing list",
+    description:
+      "Ten days out of one backpack: a four-day clothing rotation, packing cubes as an organisation system, and the dorm kit that decides whether you sleep.",
+    lede: "Ten days of backpacking is a four-day clothing rotation plus laundry, packed into a bag you can carry a kilometre in the rain. Aim for under 10kg and pack the dorm kit first.",
+    options: { type: "backpacking", days: 10, climate: "mild", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Pack for four days, wash twice",
+        body: "Ten days of clothing is a fantasy weight. Four days plus a sink wash or a laundrette covers it, and the clothes you actually re-wear are the ones you chose deliberately. Quick-dry fabrics make the sink wash viable: roll a wet garment in a towel and stand on it before hanging, and it's dry by morning.",
+      },
+      {
+        heading: "Under 10kg is the target, and it's achievable",
+        body: "Weigh the packed bag at home. Above about 10kg, walking from a station to a hostel stops being a walk and becomes a chore that shapes your decisions — you take taxis you didn't need and skip the place up the hill. The savings come from clothing volume and from not carrying 'just in case' gear you can buy anywhere.",
+      },
+      {
+        heading: "Packing cubes are an organisation system, not a compression trick",
+        body: "You'll open your bag on a bunk, in a dorm, with the lights off, next to someone asleep. One cube per category means retrieving a t-shirt without unpacking everything you own onto a shared floor. That's the actual benefit; the space saving is minor.",
+      },
+      {
+        heading: "The dorm kit",
+        body: "Earplugs, an eye mask, a head torch, a padlock, and flip-flops for the shower. Every one of them addresses a specific and near-certain event: someone packing at 4am, a light left on, a late arrival, an unlockable locker, a shared bathroom floor. Pack these first and the rest is negotiable.",
+      },
+    ],
+    extras: [
+      { id: "bp-weigh", category: "gear", label: "Weigh the packed bag before you go", note: "Above 10kg, the walk from the station starts shaping your decisions." },
+      { id: "bp-towel-roll", category: "toiletries", label: "Sink-wash routine", note: "Roll the wet garment in a towel and stand on it before hanging; dry by morning." },
+      { id: "bp-hostel-sheet", category: "gear", label: "A sleep sheet", note: "For the hostel where the linen costs extra or looks like it should." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "week-long-ski-trip-packing-list",
+    title: "Ski Trip Packing List for a Week on the Mountain",
+    h1: "Ski trip packing list for a week",
+    description:
+      "A week of skiing: what to rent and what to bring, why your boots belong in the cabin, and the sunburn nobody plans for. Includes après and travel-day items.",
+    lede: "Rent the skis, bring the helmet and goggles — fit is the part rental can't get right. And if you bring your own boots, they travel in the cabin with you, because nothing else on the trip is harder to replace.",
+    options: { type: "ski", days: 7, climate: "cold", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "Rent skis, own the things that touch your body",
+        body: "Rental skis are fine and getting them serviced is someone else's problem. Helmets and goggles are different: a helmet needs to fit your head, and rental goggles are scratched, fogged, and shared. A week of helmet rental usually costs more than a decent helmet anyway. If you own boots, bring them — badly fitted boots ruin a week faster than bad snow does.",
+      },
+      {
+        heading: "Boots go in the cabin",
+        body: "If your bag is delayed, everything in it can be replaced or rented at the resort — except boots moulded to your feet. Carry them on. It looks absurd at the gate and it is the correct decision, and it also means you're wearing or carrying the heaviest item rather than paying for it in the hold.",
+      },
+      {
+        heading: "The sunburn nobody plans for",
+        body: "Snow reflects up to 80% of UV back upward, and altitude adds roughly 4% more UV per 300m. The result is burnt nostrils, a burnt chin, and burnt lips — the surfaces facing the ground. SPF 50 in the morning, an SPF lip balm in your jacket pocket, and goggles rather than sunglasses on the mountain, because the tan line from goggles is the good outcome.",
+      },
+      {
+        heading: "Ski clothes are heavy; check the allowance",
+        body: "Salopettes, jacket, boots and helmet add up fast. Most airlines sell a discounted ski-bag allowance if booked in advance and charge punitively at the desk if not. Wear the jacket and the heaviest layer to the airport. And pack fewer après clothes than instinct suggests — the evenings are a fleece and jeans, not a wardrobe.",
+      },
+    ],
+    extras: [
+      { id: "sk-boots-cabin", category: "gear", label: "Ski boots as your cabin bag", note: "The one item a delayed suitcase makes unreplaceable." },
+      { id: "sk-ski-allowance", category: "documents", label: "Ski-bag allowance booked in advance", note: "Airlines charge several times as much at the desk." },
+      { id: "sk-boot-dryer", category: "gear", label: "Boot dryer or newspaper", note: "Wet liners on day two make every remaining day worse." },
+      { id: "sk-apres", category: "clothing", label: "One après outfit, not five", note: "Evenings are a fleece and jeans." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  // ------------------------------------------------------------ carry-on ---
+  p({
+    slug: "carry-on-only-packing-list",
+    title: "Carry-On Only Packing List: What Actually Fits",
+    h1: "Carry-on only packing list",
+    description:
+      "Travelling with hand luggage only: the liquids bag is the real constraint, not the clothes. Solid swaps, the roll method, and the two things that never leave your body.",
+    lede: "Carry-on only is usually a volume problem, not a weight problem — and the volume is mostly toiletries. Swap your bulkiest liquids for solids and the rest of the bag stops being tight.",
+    options: { type: "city", days: 5, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "The liquids bag is the binding constraint",
+        body: "One clear resealable bag, containers of 100ml or less, and the container's stated size is what counts — a half-empty 200ml bottle is confiscated. That bag is small, and shampoo, conditioner, sunscreen and shower gel will fill it before you've thought about toothpaste. Solve this first and the clothing follows easily.",
+      },
+      {
+        heading: "Solids don't count against it",
+        body: "A shampoo bar, toothpaste tablets, a solid deodorant and a stick sunscreen all travel outside the liquids bag entirely. Swapping four bottles for four solids frees the whole bag for the things that have no solid equivalent — contact lens solution, medication, anything liquid you actually need.",
+      },
+      {
+        heading: "Check your specific airline's dimensions",
+        body: "Cabin bag allowances vary by several centimetres and several kilos between carriers, and budget airlines charge more at the gate than the flight cost. Measure your bag including wheels and handles. Many airlines also allow a separate 'personal item' that goes under the seat — a bag that fits that slot effectively adds a third of your capacity for free.",
+      },
+      {
+        heading: "Roll, wear the bulk, and buy the rest",
+        body: "Rolling saves space and creases less than folding for most fabrics. The heaviest jacket and shoes go on your body through the airport, where they cost nothing. And whatever you forget, you buy — the one hard rule is that medication and documents travel on you, in the cabin, always, because those are the only two categories a destination can't sell you.",
+      },
+    ],
+    extras: [
+      { id: "co-personal-item", category: "gear", label: "A personal item that fits under the seat", note: "Most airlines allow one free; it's a third more capacity." },
+      { id: "co-measure", category: "gear", label: "Measure your bag with wheels and handles", note: "Gate sizers include them; airline websites sometimes don't mention it." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  p({
+    slug: "hand-luggage-only-week-packing-list",
+    title: "Hand Luggage Only: A One-Week Packing List",
+    h1: "Hand luggage only packing list for a week",
+    description:
+      "Seven days in a cabin bag, done by packing four days of clothes and washing once. The sink-wash routine, the fabrics that make it work, and the one-pair-of-shoes rule.",
+    lede: "Seven days fits in hand luggage if you pack four days of clothes and wash once. That single decision, not clever folding, is what makes a week of carry-on travel comfortable rather than tight.",
+    options: { type: "city", days: 7, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "Four days of clothes, one wash",
+        body: "Seven days of outfits does not fit in a cabin bag with any comfort. Four does, easily. A sink wash mid-week takes twenty minutes and turns the bag from stuffed to half-empty — which is also the margin you need for anything you buy while you're there.",
+      },
+      {
+        heading: "The sink-wash routine, so it's dry by morning",
+        body: "Wash in the evening, rinse, then lay the garment flat on a dry towel, roll the towel up tightly with the garment inside, and stand on it. That removes far more water than wringing and does less damage. Hang it after and most fabrics are dry by morning; a hotel's bathroom towel rail is often heated, which helps.",
+      },
+      {
+        heading: "Fabric choice is what makes it work",
+        body: "Merino wool resists odour for days of wear and dries fast; technical synthetics dry faster still. Cotton does neither and is why most people's carry-on attempts fail. You need fewer merino t-shirts than cotton ones to cover the same week, which is where the volume saving actually comes from.",
+      },
+      {
+        heading: "One pair of shoes on your feet",
+        body: "Shoes are the bulkiest thing in any bag. Wear the substantial pair and, if you need a second, make it something flat and packable that fills the gaps around everything else. Two pairs of shoes in a cabin bag for a week is possible; three is not, and isn't necessary.",
+      },
+    ],
+    extras: [
+      { id: "hl-merino", category: "clothing", label: "Merino or technical fabrics, not cotton", note: "Resists odour, dries overnight, and you need fewer of them." },
+      { id: "hl-wash", category: "toiletries", label: "A tube of travel wash", note: "Solid or under 100ml. Twenty minutes mid-week halves what you carry." },
+      { id: "hl-flat-shoes", category: "clothing", label: "One packable flat pair, worn substantial pair", note: "Shoes are the bulkiest thing in any bag." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  p({
+    slug: "long-haul-flight-carry-on-essentials",
+    title: "Long-Haul Flight Carry-On Essentials: What to Keep at Your Seat",
+    h1: "Long-haul flight carry-on essentials",
+    description:
+      "What belongs in the bag at your feet on a ten-hour flight: hydration, compression socks, the last-hour reset kit, and the seat-back pocket rule that saves your passport.",
+    lede: "On a long-haul flight, the bag at your feet matters more than the one in the locker. Pack for hydration, sleep, and the twenty minutes before landing when you want to feel human again.",
+    options: { type: "city", days: 10, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "Cabin air is drier than most deserts",
+        body: "Relative humidity at altitude sits around 10–20%, which is drier than the Sahara. That's the reason for the headache, the sore throat and the shrivelled contact lenses. An empty bottle filled after security, lip balm, moisturiser, and glasses instead of lenses for the flight itself deal with almost all of it. Alcohol and coffee make it worse, whatever the drinks trolley suggests.",
+      },
+      {
+        heading: "Compression socks for anything over eight hours",
+        body: "Sitting still for long periods raises the risk of deep vein thrombosis, and graduated compression socks measurably reduce it. They're cheap, they take no space, and the discomfort is minimal compared to the alternative. Walk the aisle every couple of hours regardless.",
+      },
+      {
+        heading: "The last-hour reset",
+        body: "A toothbrush, a face wipe, deodorant and a clean t-shirt in your seat bag turn the final hour into something restorative rather than endured. It matters most on the flights that land in the morning and expect you to function — which is most long-haul eastbound routes.",
+      },
+      {
+        heading: "The seat-back pocket rule",
+        body: "Anything in the seat-back pocket gets left on the plane. Passports, phones and glasses have all ended their journeys there. Use the pocket for a book and nothing else, and keep the irreplaceable items in a zipped bag at your feet. Also: medication times shift with time zones — work out the schedule before you fly, not at 3am over Greenland.",
+      },
+    ],
+    extras: [
+      { id: "lh-compression", category: "health", label: "Compression socks", note: "For any flight over eight hours; measurably lowers DVT risk." },
+      { id: "lh-reset-kit", category: "toiletries", label: "Last-hour reset kit", note: "Toothbrush, face wipe, deodorant, clean t-shirt." },
+      { id: "lh-glasses", category: "health", label: "Glasses instead of contact lenses", note: "Cabin humidity runs 10–20% — drier than the Sahara." },
+      { id: "lh-med-schedule", category: "health", label: "Your medication schedule across time zones", note: "Work it out before you fly, not at 3am over the Atlantic." },
+      { id: "lh-downloads", category: "tech", label: "Everything downloaded in advance", note: "In-flight Wi-Fi is slow, expensive, or absent." },
+      { id: "lh-seatback", category: "gear", label: "Nothing valuable in the seat-back pocket", note: "It is where passports go to be left behind." },
+    ],
+    related: ["packing-list-for-international-travel", "travel-checklist-before-leaving"],
+  }),
+
+  // -------------------------------------------------------------- family ---
+  p({
+    slug: "family-beach-holiday-packing-list",
+    title: "Family Beach Holiday Packing List (With Kids)",
+    h1: "Family beach holiday packing list",
+    description:
+      "A week at the beach with children: UV swimsuits instead of endless sunscreen reapplication, the shade you have to bring yourself, and the wet bag that saves the car.",
+    lede: "With children at the beach, sun protection is most of the job — and a UV swimsuit does more of it than any amount of chasing a wet child with a sunscreen bottle.",
+    options: { type: "beach", days: 7, climate: "hot", carryOnOnly: false, checkedBag: true, kids: true },
+    advice: [
+      {
+        heading: "Cover them with fabric, not just cream",
+        body: "A long-sleeved UV swimsuit blocks sun continuously without needing reapplication every eighty minutes to a child who is in the sea. Sunscreen still goes on faces, hands and feet, but the surface area you're responsible for drops enormously. Add a wide-brimmed hat with a chin strap, because the ones without get lost on day one.",
+      },
+      {
+        heading: "Bring your own shade",
+        body: "Most beaches have none, and hiring a parasol isn't always possible. A pop-up beach tent gives a baby somewhere to nap and everyone else somewhere to retreat at midday, when the UV index peaks and small children stop enjoying themselves. It's bulky and it is consistently the item families say they'd bring again.",
+      },
+      {
+        heading: "Sand and water need a logistics answer",
+        body: "A wet bag for swimwear keeps the rest of the beach bag dry and the hire car survivable. Baby powder is the standard trick for getting sand off skin — it dries the moisture the sand is clinging to and it brushes straight off. Bring more towels than seems reasonable; they're never dry when you need the next one.",
+      },
+      {
+        heading: "Medication, dosing and the travel day",
+        body: "Children's paracetamol and ibuprofen dose by weight, and formulations differ between countries — bring what you already know how to use, plus a thermometer. For the flight, pack a change of clothes per child in the cabin bag and a spare top for whichever adult is holding them. Downloaded shows, not streamed ones.",
+      },
+    ],
+    extras: [
+      { id: "fb-uv-suits", category: "kids", label: "Long-sleeved UV swimsuits", note: "Continuous protection without chasing a wet child with a bottle." },
+      { id: "fb-beach-tent", category: "kids", label: "Pop-up beach tent", note: "Most beaches have no shade, and midday UV is when it stops being fun." },
+      { id: "fb-wet-bag", category: "kids", label: "Wet bag for swimwear", note: "Keeps the beach bag and the hire car survivable." },
+      { id: "fb-baby-powder", category: "kids", label: "Baby powder", note: "The standard trick for getting sand off skin — it brushes straight off." },
+      { id: "fb-chin-strap-hat", category: "kids", label: "Sun hats with chin straps", note: "The ones without get lost on the first day." },
+      { id: "fb-armbands", category: "kids", label: "Armbands or float vests you trust", note: "Rental gear at the pool is a lottery on both fit and condition." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "family-city-break-packing-list",
+    title: "Family City Break Packing List: Four Days With Kids",
+    h1: "Family city break packing list",
+    description:
+      "A city break with children: the carrier-versus-stroller decision on metro stairs, the photo you take every morning, and why snacks are a crowd-control tool.",
+    lede: "A city break with kids lives or dies on transport and queues. Decide carrier versus stroller before you book, take a photo of each child every morning, and carry more snacks than the day appears to need.",
+    options: { type: "city", days: 4, climate: "mild", carryOnOnly: false, checkedBag: true, kids: true },
+    advice: [
+      {
+        heading: "Carrier or stroller is a route decision",
+        body: "Older European metro systems are stairs, cobblestones and narrow pavements, and a stroller becomes something you carry rather than push. A carrier handles all of that and frees both hands, at the cost of your back. Check whether your specific stations have lifts before deciding — many networks publish exactly that map, and it changes the answer city by city.",
+      },
+      {
+        heading: "The morning photo",
+        body: "Take a picture of each child at the start of every day. If they get separated from you in a crowd, you can show someone precisely what they're wearing rather than describing it. Pair it with a card in their pocket carrying your phone number with the country code — old technology, works without a battery, and works when the child is too upset to recite a number.",
+      },
+      {
+        heading: "Snacks are crowd control",
+        body: "Museum queues, delayed trains and restaurants that don't serve until eight are the actual difficulty of travelling with children, and being hungry turns every one of them into a bad hour. Carry more than the day looks like it needs. A refillable bottle each removes the second half of the same problem.",
+      },
+      {
+        heading: "One thing a day, and a change of clothes in the day bag",
+        body: "The itinerary that works with children has one anchor activity and a lot of slack around it. Whatever else happens, the day succeeded. And the spare clothes belong in the bag you're carrying, not back at the hotel — the moment you need them, the hotel is forty minutes away.",
+      },
+    ],
+    extras: [
+      { id: "fc-morning-photo", category: "kids", label: "A photo of each child, taken that morning", note: "Shows exactly what they're wearing if you get separated." },
+      { id: "fc-contact-card", category: "kids", label: "A card in each pocket with your number", note: "With the country code. Works without a battery." },
+      { id: "fc-carrier", category: "kids", label: "Carrier or stroller — decided by the metro map", note: "Older networks are stairs; check whether your stations have lifts." },
+      { id: "fc-day-bag-change", category: "kids", label: "Spare clothes in the day bag", note: "Not at the hotel, which is always forty minutes away." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  // ------------------------------------------------------------ activity ---
+  p({
+    slug: "camping-packing-list",
+    title: "Camping Packing List: Shelter, Sleep, Cook",
+    h1: "Camping packing list",
+    description:
+      "A camping list organised by the three systems that matter — shelter, sleep and cook — plus the R-value most people ignore and the tarp that doubles your usable space.",
+    lede: "Camping packing has three systems: shelter, sleep and cook. Get those right and everything else is comfort. The most commonly underestimated item is the sleeping mat, not the sleeping bag.",
+    options: { type: "hiking", days: 3, climate: "mild", carryOnOnly: false, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "The mat matters more than the bag",
+        body: "Cold nights are usually a mat problem. The ground conducts heat away from your body far faster than the air does, and a sleeping bag compresses to nothing underneath you, so it insulates you from nothing. A mat's R-value is the number to check: roughly 2 for summer, 4 or more for cold shoulder-season nights. People spend on the bag and shiver on a cheap mat.",
+      },
+      {
+        heading: "Pitch it once at home first",
+        body: "The first time you put up a new tent should not be in the dark, in the rain, in front of an audience. Pitch it in a garden or a park, confirm every pole and peg is in the bag, and time yourself. This also catches the missing guyline that the shop packed without.",
+      },
+      {
+        heading: "A tarp doubles your usable space",
+        body: "Rain turns a tent into a two-person box you sit inside. A cheap tarp strung over the entrance creates a dry area to cook, take boots off, and sit — which is the difference between waiting out the weather and enjoying the trip. It weighs a few hundred grams and is the most consistently recommended optional item.",
+      },
+      {
+        heading: "Water, fire and what you take home",
+        body: "Know before you go how you'll carry water and whether you need to treat it. Check the fire rules for the site and the season — many places ban open fires outright in summer, and a stove is the reliable answer regardless. And pack out everything you brought in, including food waste, which means carrying a rubbish bag you planned for rather than one you improvise.",
+      },
+    ],
+    extras: [
+      { id: "cp-tent", category: "gear", label: "Tent, pitched once at home first", note: "Confirms every pole, peg and guyline is actually in the bag." },
+      { id: "cp-mat", category: "gear", label: "Sleeping mat with the right R-value", note: "About 2 for summer, 4+ for cold nights. This is what keeps you warm." },
+      { id: "cp-tarp", category: "gear", label: "Tarp", note: "Turns a rainy day from waiting-it-out into a dry place to cook and sit." },
+      { id: "cp-stove", category: "gear", label: "Stove, fuel, and two ways to light it" },
+      { id: "cp-water-plan", category: "gear", label: "Water carrying and treatment sorted", note: "Check the site's supply before you arrive, not after." },
+      { id: "cp-rubbish", category: "gear", label: "Rubbish bags", note: "Everything you brought in comes out with you, food waste included." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "road-trip-packing-list",
+    title: "Road Trip Packing List: The Car, the Bags & the Documents",
+    h1: "Road trip packing list",
+    description:
+      "A road trip list for the trip where you can overpack: the overnight bag that saves you unloading the boot, the documents police ask for, and the offline map that works in the canyon.",
+    lede: "A road trip removes the weight limit, which is exactly the trap. Pack a separate overnight bag so you're not unloading the whole boot at every motel, and download the maps before you lose signal.",
+    options: { type: "city", days: 7, climate: "mild", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "The overnight bag is the whole trick",
+        body: "On a multi-stop road trip you'll check into somewhere new most nights. Without a small bag holding a change of clothes and your toiletries, you unload the entire boot every evening and repack it every morning. One small bag that lives on top, restocked from the big one every couple of days, removes the single most tedious part of driving holidays.",
+      },
+      {
+        heading: "The documents a roadside stop asks for",
+        body: "Driving licence, and an International Driving Permit where required — several countries insist on one even for EU or US licences. Vehicle registration, insurance documentation, and breakdown cover details you can find without signal. If you're crossing borders in a hire car, check the rental agreement actually permits it; plenty don't, and the insurance voids at the frontier.",
+      },
+      {
+        heading: "Offline maps and a phone mount",
+        body: "Coverage disappears in canyons, mountains and long rural stretches — exactly the places you're driving to. Download the region in advance. A phone mount and a charger per person avoid the two most common in-car arguments, and a paper map or written route as a backup costs nothing and works when the phone overheats on the dashboard, which it will.",
+      },
+      {
+        heading: "The boot is not a hotel room",
+        body: "No weight limit means people pack six pairs of shoes and a coffee machine. Keep the categories the same as any other trip and use the extra capacity for the things that genuinely improve a drive: a cooler with cold drinks, real snacks, a blanket, and a sunshade for when the car is parked in the sun all afternoon.",
+      },
+    ],
+    extras: [
+      { id: "rt-overnight-bag", category: "gear", label: "A separate overnight bag", note: "So you're not unloading the entire boot at every stop." },
+      { id: "rt-idp", category: "documents", label: "IDP, registration, insurance and breakdown cover", note: "Findable offline; several countries require the IDP even for EU and US licences." },
+      { id: "rt-cross-border", category: "documents", label: "Confirm the hire car may cross borders", note: "Many agreements forbid it and void the insurance if you do." },
+      { id: "rt-mount", category: "tech", label: "Phone mount and a charger per person" },
+      { id: "rt-offline-maps", category: "tech", label: "Maps downloaded for the whole route", note: "Canyons and mountain passes are exactly where coverage stops." },
+      { id: "rt-cooler", category: "gear", label: "Cooler, snacks and a blanket" },
+      { id: "rt-sunshade", category: "gear", label: "Windscreen sunshade", note: "For the afternoon the car spends in a car park at 35°C." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "festival-packing-list",
+    title: "Festival Packing List: Three Days, No Plug Sockets",
+    h1: "Festival packing list",
+    description:
+      "A festival list for the conditions rather than the photos: mud, no charging, no shade, banned glass, and a tent you have to find again at 2am.",
+    lede: "Assume mud, no power, no shade and no signal. A festival list is mostly about staying dry, keeping your phone alive, and being able to find your own tent in the dark.",
+    options: { type: "backpacking", days: 3, climate: "mild", carryOnOnly: false, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "Everything gets wet, so plan the recovery",
+        body: "Wellies and waterproofs are obvious. What's less obvious is spare socks — more pairs than days — and a dry bag holding one complete change of clothes that never comes out until you genuinely need it. Wet feet for three days is how a good weekend turns miserable, and it's entirely preventable with two hundred grams of spare socks.",
+      },
+      {
+        heading: "You will not charge anything",
+        body: "Charging tents exist, have queues measured in hours, and cost money. Bring a power bank sized for the whole weekend, put the phone in low-power mode from the start, and agree a physical meeting point and time with your group — because signal at a festival site collapses under the load regardless of how many bars the phone shows.",
+      },
+      {
+        heading: "Find your tent again",
+        body: "Ten thousand identical tents in a field look exactly the same at 2am. A flag, a tall inflatable, or a distinctive object on a pole makes yours findable. Take a photo of the nearest landmark and note the row when you pitch. This sounds trivial until it's raining and you've been walking the same field for forty minutes.",
+      },
+      {
+        heading: "The rules and the cash",
+        body: "Almost every festival bans glass entirely, and many restrict bag sizes at arena entrances — check both before you pack rather than at the gate, where confiscation is the only option offered. Bring some cash: card readers at independent food stalls fail regularly when the site network is saturated. And sunscreen, because a field has no shade and people forget that a cloudy festival still burns.",
+      },
+    ],
+    extras: [
+      { id: "fs-wellies", category: "clothing", label: "Wellies and waterproofs", note: "Plus more pairs of socks than days." },
+      { id: "fs-dry-change", category: "clothing", label: "One complete change of clothes in a dry bag", note: "It stays sealed until you actually need it." },
+      { id: "fs-power-bank", category: "tech", label: "A power bank sized for the whole weekend", note: "Charging tents have hour-long queues and charge for the privilege." },
+      { id: "fs-flag", category: "gear", label: "A flag or tall marker for your tent", note: "Ten thousand identical tents look identical at 2am." },
+      { id: "fs-no-glass", category: "gear", label: "Nothing glass", note: "Banned at essentially every festival; confiscated at the gate." },
+      { id: "fs-cash", category: "documents", label: "Cash", note: "Independent stalls' card readers fail when the site network saturates." },
+      { id: "fs-earplugs", category: "gear", label: "Earplugs — for sleeping and for the front row" },
+      { id: "fs-bin-bags", category: "gear", label: "Bin bags", note: "A poncho, a groundsheet, and a way to take your rubbish home." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-budget-for-a-trip"],
+  }),
+
+  p({
+    slug: "honeymoon-packing-list",
+    title: "Honeymoon Packing List: Names, Dress Codes & Two Weeks",
+    h1: "Honeymoon packing list",
+    description:
+      "A honeymoon packing list including the thing that ruins them: booking in a married name your passport doesn't have yet. Plus resort dress codes and the certificate worth carrying.",
+    lede: "Book and travel in the name printed in your passport, whatever you've changed it to since. Beyond that, a honeymoon packs like a beach holiday with two more evenings that matter.",
+    options: { type: "beach", days: 10, climate: "hot", carryOnOnly: false, checkedBag: true, kids: false },
+    advice: [
+      {
+        heading: "The name on the ticket must match the passport",
+        body: "This is the single most common way honeymoons go wrong before they start. If you've changed your name but not yet your passport, book every flight, hotel and transfer in your current passport name. Airlines routinely refuse boarding on a mismatch and treat a name change as a rebooking, at full fare. Change the passport first or travel in the old name — not half of each.",
+      },
+      {
+        heading: "Carry a copy of the marriage certificate",
+        body: "Not because anyone demands it, but because resorts, airlines and restaurants hand out upgrades, free champagne and better tables to honeymooners, and a fair number ask for something to back it up. A photo on your phone is enough. Mention it at booking too, not just on arrival — that's when the room allocation is actually decided.",
+      },
+      {
+        heading: "Plan for more than one good evening",
+        body: "The usual advice — one nice outfit for the week — doesn't hold here. Two or three evenings will be occasions, and plenty of resort restaurants enforce a dress code after six, which frequently means no shorts and closed shoes for men. Check the resort's stated code before packing; it's usually on their website and it's usually stricter than people expect.",
+      },
+      {
+        heading: "Leave space, and split the bags",
+        body: "You will buy things. Pack the outbound bags at about 80% and the return journey stops being a negotiation. And split each person's clothes across both suitcases: if one bag is delayed, you both still have something to wear, which is a better first evening than one of you in the clothes you flew in.",
+      },
+    ],
+    extras: [
+      { id: "hm-name-match", category: "documents", label: "Every booking in your passport name", note: "A mismatch is refused boarding, treated as a rebooking at full fare." },
+      { id: "hm-certificate", category: "documents", label: "A photo of the marriage certificate", note: "Resorts hand out upgrades and often ask for something to back it up." },
+      { id: "hm-two-evenings", category: "clothing", label: "Two or three evening outfits", note: "Resort restaurants commonly enforce a dress code after six." },
+      { id: "hm-split-bags", category: "clothing", label: "Split your clothes across both suitcases", note: "One delayed bag then leaves you both with something to wear." },
+      { id: "hm-space", category: "gear", label: "Pack the outbound bags to 80%", note: "The return journey is where the space runs out." },
+    ],
+    related: ["packing-list-for-international-travel", "how-to-plan-a-trip-step-by-step"],
+  }),
+
+  p({
+    slug: "digital-nomad-packing-list",
+    title: "Digital Nomad Packing List: Work Setup in a Carry-On",
+    h1: "Digital nomad packing list",
+    description:
+      "A packing list for working while travelling: the desk setup that fits a cabin bag, one charger instead of four, connectivity with a real fallback, and the documents borders ask for.",
+    lede: "Working while travelling means the desk comes with you: laptop, stand, keyboard, and one charger that runs everything. The clothes are a four-day rotation — the setup is what needs thought.",
+    options: { type: "city", days: 21, climate: "mild", carryOnOnly: true, checkedBag: false, kids: false },
+    advice: [
+      {
+        heading: "One charger, not four",
+        body: "A single multi-port GaN charger of 65W or more runs a laptop, phone, headphones and tablet from one socket and one brick. It replaces four power supplies and, more usefully, means one plug adapter rather than a pile. This is the highest-value swap on the list for both weight and daily friction.",
+      },
+      {
+        heading: "The stand is the difference between a week and a month",
+        body: "A laptop on a café table puts your neck at the wrong angle for eight hours a day. A folding stand plus a compact keyboard weighs under a kilo and turns any surface into a workstation you can use for months rather than days. If you're working full-time on the road, this is not an accessory.",
+      },
+      {
+        heading: "Connectivity needs a second answer",
+        body: "One eSIM is a plan; two providers is a fallback. Café Wi-Fi fails, apartment internet is slower than advertised, and a call you cannot take costs more than the data. Check the phone allows hotspot use on the plan you buy, and test the backup before the day you need it. Noise-cancelling headphones are working equipment here, not entertainment.",
+      },
+      {
+        heading: "Documents and backups",
+        body: "Some countries ask for proof of onward travel at check-in or immigration, and some digital nomad visas require proof of income and health insurance. Have them in a folder that works offline. For the work itself: cloud sync plus an encrypted physical drive, because the failure you're insuring against — a stolen laptop in a café — takes out both the machine and the local copy.",
+      },
+    ],
+    extras: [
+      { id: "dn-gan", category: "tech", label: "One 65W+ multi-port GaN charger", note: "Replaces four bricks and, more usefully, three plug adapters." },
+      { id: "dn-stand", category: "tech", label: "Folding laptop stand and compact keyboard", note: "Under a kilo, and the reason you can work for months rather than a week." },
+      { id: "dn-esims", category: "tech", label: "Two eSIM providers, one tested as backup", note: "Confirm hotspot use is allowed on the plan you buy." },
+      { id: "dn-anc", category: "tech", label: "Noise-cancelling headphones", note: "Working equipment, not entertainment." },
+      { id: "dn-onward", category: "documents", label: "Proof of onward travel and insurance, offline", note: "Asked for at check-in and immigration more often than you'd expect." },
+      { id: "dn-encrypted-drive", category: "tech", label: "Encrypted backup drive, kept separately", note: "A stolen laptop takes out the machine and the local copy at once." },
+    ],
+    related: ["packing-list-for-international-travel", "trip-planner-app-no-subscription"],
+  }),
+];
+
+export const CURATED_BY_SLUG = new Map(CURATED_PAGES.map((page) => [page.slug, page]));

--- a/src/data/packingList/rules.ts
+++ b/src/data/packingList/rules.ts
@@ -1,0 +1,809 @@
+import type { PackingOptions, Rule } from "./types";
+
+/**
+ * The rule set behind every generated list.
+ *
+ * Order matters: rules are applied top to bottom and the first rule to claim an
+ * item id wins, so a trip-type-specific note ("SPF 50 — snow reflects most of it
+ * straight back at you") beats the generic climate one. Give two rules the same
+ * id when they mean the same object and you want that de-duplication.
+ *
+ * This module is imported by the client island, so keep it data — no imports
+ * beyond types, no helpers that pull in dependencies.
+ */
+
+/** Clothing counts. Capped, because past a week the answer is laundry. */
+const perDay = (days: number, cap: number, extra = 0) =>
+  Math.min(days, cap) + extra;
+
+const tops = (o: PackingOptions) =>
+  o.days <= 3 ? o.days : Math.min(Math.ceil(o.days * 0.7), 7);
+const bottoms = (o: PackingOptions) =>
+  Math.max(2, Math.min(Math.ceil(o.days / 2), 4));
+
+export const RULES: readonly Rule[] = [
+  // ---------------------------------------------------------------- base ---
+  {
+    items: [
+      {
+        id: "passport",
+        category: "documents",
+        label: "Passport",
+        note: "Valid at least 6 months beyond your return date — many countries refuse entry otherwise.",
+      },
+      {
+        id: "visa",
+        category: "documents",
+        label: "Visa or entry authorisation",
+        note: "Check the rules even for visa-free travel; several regions now want an online pre-authorisation.",
+      },
+      {
+        id: "boarding-passes",
+        category: "documents",
+        label: "Boarding passes",
+        note: "Plus a screenshot, for when the airline app can't reach the internet.",
+      },
+      {
+        id: "insurance",
+        category: "documents",
+        label: "Travel insurance policy",
+        note: "Policy number and the 24-hour emergency line, saved offline.",
+      },
+      {
+        id: "bookings",
+        category: "documents",
+        label: "Accommodation confirmations",
+        note: "Some border officers ask for proof of where you're staying.",
+      },
+      {
+        id: "licence",
+        category: "documents",
+        label: "Driving licence",
+        note: "Add an International Driving Permit if you're renting — plenty of countries require one.",
+      },
+      {
+        id: "doc-copies",
+        category: "documents",
+        label: "Copies of your passport",
+        note: "One photo on your phone, one on paper packed separately from the original.",
+      },
+      {
+        id: "cards",
+        category: "documents",
+        label: "Two payment cards on different networks",
+        note: "Carried in different bags, so one loss isn't total.",
+      },
+      {
+        id: "cash",
+        category: "documents",
+        label: "A small amount of local cash",
+        note: "For the taxi, the locker, and the place that has been cash-only since 1974.",
+      },
+
+      {
+        id: "underwear",
+        category: "clothing",
+        label: (o) => `Underwear × ${perDay(o.days, 7, 1)}`,
+      },
+      {
+        id: "socks",
+        category: "clothing",
+        label: (o) => `Socks × ${perDay(o.days, 7, 1)}`,
+        // Cold trips used to get a second "wool socks" line on top of this
+        // one, which added up to thirteen pairs for ten days.
+        note: (o) =>
+          o.climate === "cold"
+            ? "Wool, not cotton. The pair that's damp at lunchtime is why your feet are cold at four."
+            : undefined,
+      },
+      {
+        id: "tops",
+        category: "clothing",
+        label: (o) => `Tops × ${tops(o)}`,
+        note: "Built around one or two base colours, so every top works with every bottom.",
+      },
+      {
+        id: "bottoms",
+        category: "clothing",
+        label: (o) => `Bottoms × ${bottoms(o)}`,
+      },
+      {
+        id: "layers",
+        category: "clothing",
+        label: "Two layers",
+        note: "A sweater or hoodie plus a jacket suited to where you're going.",
+      },
+      { id: "sleepwear", category: "clothing", label: "Sleepwear" },
+      {
+        id: "nice-outfit",
+        category: "clothing",
+        label: "One outfit for a nice evening",
+        note: "One. Anything you can't name the occasion for stays home.",
+      },
+      {
+        id: "shoes",
+        category: "clothing",
+        label: "Shoes — walking, casual, and one dressier pair",
+        note: "Three pairs maximum. Wear the heaviest onto the plane.",
+      },
+
+      {
+        id: "toothbrush",
+        category: "toiletries",
+        label: "Toothbrush and toothpaste",
+      },
+      { id: "deodorant", category: "toiletries", label: "Deodorant" },
+      {
+        id: "shampoo",
+        category: "toiletries",
+        label: "Travel-size shampoo and soap",
+        note: "Or skip them entirely and use whatever the hotel provides.",
+      },
+      { id: "razor", category: "toiletries", label: "Razor and shaving kit" },
+      {
+        id: "skincare",
+        category: "toiletries",
+        label: "Skincare basics",
+        note: "The products you actually use daily — not the full bathroom shelf.",
+      },
+      { id: "hairbrush", category: "toiletries", label: "Hairbrush or comb" },
+      {
+        id: "contacts",
+        category: "toiletries",
+        label: "Contact lenses, solution, and backup glasses",
+      },
+
+      {
+        id: "prescriptions",
+        category: "health",
+        label: "Prescription medication in its original packaging",
+        note: "In your carry-on, with a few days spare in case you're delayed getting home.",
+      },
+      {
+        id: "prescription-copy",
+        category: "health",
+        label: "A copy of the prescription",
+        note: "For anything controlled or injectable — some countries do check.",
+      },
+      { id: "painkillers", category: "health", label: "Painkillers" },
+      {
+        id: "plasters",
+        category: "health",
+        label: "Plasters and blister care",
+      },
+      {
+        id: "stomach-kit",
+        category: "health",
+        label: "Anti-diarrheal and rehydration sachets",
+      },
+      { id: "antihistamines", category: "health", label: "Antihistamines" },
+
+      { id: "phone", category: "tech", label: "Phone and charger" },
+      {
+        id: "adapter",
+        category: "tech",
+        label: "Power adapter for your destination's plug type",
+        note: "Modern chargers take 100–240V, so you need the plug shape, rarely a voltage converter.",
+      },
+      {
+        id: "power-bank",
+        category: "tech",
+        label: "Power bank",
+        note: "Carry-on only, and most airlines cap it at 100Wh (about 27,000 mAh).",
+      },
+      {
+        id: "spare-cable",
+        category: "tech",
+        label: "A spare charging cable",
+        note: "For the device you'd most hate to lose the use of.",
+      },
+      { id: "headphones", category: "tech", label: "Headphones" },
+      {
+        id: "esim",
+        category: "tech",
+        label: "Data sorted before you fly",
+        note: "An eSIM for your destination or a roaming plan you've confirmed — not airport Wi-Fi roulette.",
+      },
+
+      {
+        id: "daypack",
+        category: "gear",
+        label: "A daypack or crossbody bag that zips",
+      },
+      {
+        id: "water-bottle",
+        category: "gear",
+        label: "Empty water bottle",
+        note: "Fill it after security.",
+      },
+      {
+        id: "pen",
+        category: "gear",
+        label: "A pen",
+        note: "Paper arrival cards still exist in plenty of countries.",
+      },
+      {
+        id: "laundry-bag",
+        category: "gear",
+        label: "A bag for worn clothes",
+      },
+    ],
+  },
+
+  // ----------------------------------------------------------- trip type ---
+  {
+    when: { types: ["beach"] },
+    items: [
+      {
+        id: "swimsuits",
+        category: "clothing",
+        label: "Two swimsuits",
+        note: "One dries while you wear the other.",
+      },
+      { id: "sandals", category: "clothing", label: "Flip-flops or sandals" },
+      { id: "cover-up", category: "clothing", label: "A light cover-up" },
+      { id: "sun-hat", category: "clothing", label: "Wide-brimmed sun hat" },
+      {
+        id: "sunglasses",
+        category: "gear",
+        label: "Sunglasses",
+        note: "Polarised, if you'll be near water all week.",
+      },
+      {
+        id: "sunscreen",
+        category: "toiletries",
+        label: "Reef-safe SPF 50",
+        note: "Several beach destinations now ban oxybenzone sunscreens outright.",
+      },
+      { id: "after-sun", category: "toiletries", label: "After-sun or aloe" },
+      {
+        id: "dry-bag",
+        category: "gear",
+        label: "Dry bag for phone and cards",
+      },
+      {
+        id: "quick-dry-towel",
+        category: "gear",
+        label: "Quick-dry towel",
+        note: "Hotel pool towels generally aren't allowed to leave the property.",
+      },
+      {
+        id: "beach-shoes",
+        category: "clothing",
+        label: "Water shoes",
+        note: "Only if you're going somewhere rocky or reefy — otherwise skip them.",
+      },
+    ],
+  },
+  {
+    when: { types: ["city"] },
+    items: [
+      {
+        id: "walking-shoes",
+        category: "clothing",
+        label: "Your most broken-in walking shoes",
+        note: "This is the entire trip. Nothing new, nothing you're 'sure will be fine'.",
+      },
+      {
+        id: "smart-casual",
+        category: "clothing",
+        label: "A smart-casual layer",
+        note: "Enough restaurants still have a dress code to make this worth the space.",
+      },
+      { id: "umbrella", category: "gear", label: "Compact umbrella" },
+      {
+        id: "blister-plasters",
+        category: "health",
+        label: "Blister plasters",
+        note: "Packed before you need them, not bought in a foreign pharmacy at 9pm.",
+      },
+      {
+        id: "transit-card",
+        category: "documents",
+        label: "A contactless card you've checked works abroad",
+        note: "Most metro systems now take tap-to-pay; some only take local cards.",
+      },
+    ],
+  },
+  {
+    when: { types: ["hiking"] },
+    items: [
+      {
+        id: "boots",
+        category: "clothing",
+        label: "Broken-in hiking boots or trail shoes",
+        note: "Never new. A first-day blister ruins the other six.",
+      },
+      {
+        id: "base-layers",
+        category: "clothing",
+        label: "Merino or synthetic base layers",
+        note: "Cotton holds sweat, stays wet, and cools you down when you least want it.",
+      },
+      {
+        id: "shell",
+        category: "clothing",
+        label: "Waterproof shell jacket",
+      },
+      {
+        id: "hiking-socks",
+        category: "clothing",
+        label: (o) => `Hiking socks × ${perDay(o.days, 5, 1)}`,
+        note: "Keep one pair sealed and dry no matter what the day does.",
+      },
+      {
+        id: "head-torch",
+        category: "gear",
+        label: "Head torch and spare batteries",
+      },
+      {
+        id: "offline-maps",
+        category: "tech",
+        label: "Offline maps downloaded",
+        note: "Do it on hotel Wi-Fi. Trailheads are where signal goes to die.",
+      },
+      {
+        id: "water-capacity",
+        category: "gear",
+        label: "Two litres of water capacity",
+        note: "Bottles or a bladder — whichever you'll actually drink from while moving.",
+      },
+      { id: "trail-snacks", category: "gear", label: "Trail snacks" },
+      {
+        id: "blister-kit",
+        category: "health",
+        label: "Blister kit — tape, plasters, a needle",
+      },
+      {
+        id: "sunscreen",
+        category: "toiletries",
+        label: "Sunscreen and SPF lip balm",
+        note: "Burn risk climbs roughly 4% for every 300m of altitude.",
+      },
+      {
+        id: "paper-map",
+        category: "gear",
+        label: "Paper map and a whistle",
+        note: "The backup that doesn't have a battery.",
+      },
+    ],
+  },
+  {
+    when: { types: ["business"] },
+    items: [
+      {
+        id: "suit",
+        category: "clothing",
+        label: "Suit or equivalent",
+        note: "Folded over tissue paper, or in a garment bag if the airline lets you.",
+      },
+      {
+        id: "dress-shoes",
+        category: "clothing",
+        label: "Dress shoes, plus a comfortable pair for transit",
+      },
+      { id: "laptop", category: "tech", label: "Laptop and charger" },
+      {
+        id: "presentation-backup",
+        category: "tech",
+        label: "Your presentation backed up twice",
+        note: "Cloud plus a USB stick. Conference Wi-Fi fails at exactly the wrong moment.",
+      },
+      { id: "business-cards", category: "documents", label: "Business cards" },
+      {
+        id: "wrinkle-spray",
+        category: "toiletries",
+        label: "Wrinkle-release spray",
+        note: "Or plan ten minutes with the hotel iron the evening you arrive.",
+      },
+      {
+        id: "expenses",
+        category: "documents",
+        label: "Somewhere to keep receipts",
+        note: "A physical envelope or a photo-per-receipt habit. Reimbursement is easier same-day.",
+      },
+    ],
+  },
+  {
+    when: { types: ["ski"] },
+    items: [
+      {
+        id: "ski-jacket",
+        category: "clothing",
+        label: "Ski jacket and salopettes",
+      },
+      {
+        id: "thermals",
+        category: "clothing",
+        label: "Two sets of thermal base layers",
+        note: "One on, one drying.",
+      },
+      {
+        id: "ski-socks",
+        category: "clothing",
+        label: (o) => `Ski socks × ${perDay(o.days, 7)}`,
+        note: "Tall, thin, and never cotton. Two pairs at once causes blisters, not warmth.",
+      },
+      {
+        id: "gloves",
+        category: "clothing",
+        label: "Gloves or mittens, plus thin liners",
+      },
+      {
+        id: "goggles",
+        category: "gear",
+        label: "Goggles",
+        note: "Bring a low-light lens too if you have one — flat light is the norm, not the exception.",
+      },
+      {
+        id: "helmet",
+        category: "gear",
+        label: "Helmet",
+        note: "A week of rental costs more than most helmets, and yours actually fits.",
+      },
+      { id: "neck-gaiter", category: "clothing", label: "Neck gaiter or buff" },
+      {
+        id: "sunscreen",
+        category: "toiletries",
+        label: "SPF 50 and SPF lip balm",
+        note: "Snow reflects up to 80% of UV straight back up at your face.",
+      },
+      {
+        id: "apres-boots",
+        category: "clothing",
+        label: "Après boots with actual grip",
+        note: "Resort villages are compacted ice by Wednesday.",
+      },
+      {
+        id: "lift-pass-pocket",
+        category: "gear",
+        label: "Lift-pass holder or armband pocket",
+      },
+      { id: "hand-warmers", category: "gear", label: "Hand warmers" },
+    ],
+  },
+  {
+    when: { types: ["backpacking"] },
+    items: [
+      {
+        id: "backpack",
+        category: "gear",
+        label: "Backpack with a rain cover",
+        note: "Fitted to your torso length, not your height.",
+      },
+      {
+        id: "padlock",
+        category: "gear",
+        label: "Padlock for hostel lockers",
+      },
+      {
+        id: "quick-dry-towel",
+        category: "gear",
+        label: "Quick-dry travel towel",
+        note: "Hostels charge for towels roughly as often as they don't.",
+      },
+      {
+        id: "sink-laundry",
+        category: "toiletries",
+        label: "Universal sink plug and travel wash",
+      },
+      {
+        id: "shower-sandals",
+        category: "clothing",
+        label: "Flip-flops for shared showers",
+      },
+      {
+        id: "earplugs",
+        category: "gear",
+        label: "Earplugs and an eye mask",
+        note: "The dorm survival kit. Someone will pack at 4am.",
+      },
+      {
+        id: "packing-cubes",
+        category: "gear",
+        label: "Packing cubes",
+        note: "One per category, so you're not unpacking the whole bag on a bunk.",
+      },
+      {
+        id: "head-torch",
+        category: "gear",
+        label: "Head torch",
+        note: "For late arrivals and dorms with the lights already off.",
+      },
+      {
+        id: "emergency-snacks",
+        category: "gear",
+        label: "A day's worth of snacks",
+        note: "For the bus that leaves four hours after it said it would.",
+      },
+    ],
+  },
+
+  // ------------------------------------------------------------- climate ---
+  {
+    when: { climates: ["hot"] },
+    items: [
+      {
+        id: "light-fabrics",
+        category: "clothing",
+        label: "Loose, light-coloured natural fabrics",
+        note: "Linen and cotton move air. Synthetics trap it.",
+      },
+      { id: "sunscreen", category: "toiletries", label: "SPF 50 sunscreen" },
+      { id: "sun-hat", category: "clothing", label: "Sun hat" },
+      { id: "sunglasses", category: "gear", label: "Sunglasses" },
+      {
+        id: "electrolytes",
+        category: "health",
+        label: "Electrolyte tablets",
+        note: "Cheaper and lighter than the day you lose to heat exhaustion.",
+      },
+      { id: "insect-repellent", category: "health", label: "Insect repellent" },
+    ],
+  },
+  {
+    when: { climates: ["tropical"] },
+    items: [
+      {
+        id: "insect-repellent",
+        category: "health",
+        label: "Insect repellent with DEET or picaridin",
+        note: "Citronella wristbands do not work in a dengue zone.",
+      },
+      {
+        id: "rain-shell",
+        category: "clothing",
+        label: "Lightweight rain shell",
+        note: "Tropical rain arrives hard and leaves fast — you need shedding, not insulation.",
+      },
+      {
+        id: "quick-dry-clothing",
+        category: "clothing",
+        label: "Quick-dry clothing",
+        note: "At 90% humidity, cotton simply never dries.",
+      },
+      {
+        id: "foot-powder",
+        category: "health",
+        label: "Anti-fungal foot powder",
+      },
+      {
+        id: "water-treatment",
+        category: "health",
+        label: "A filter bottle or purification tablets",
+        note: "Also spares you a fortnight of single-use plastic.",
+      },
+      { id: "sunscreen", category: "toiletries", label: "SPF 50 sunscreen" },
+      {
+        id: "modest-layer",
+        category: "clothing",
+        label: "Shoulders-and-knees layer",
+        note: "Temples and religious sites across the tropics enforce it, often at the door.",
+      },
+    ],
+  },
+  {
+    when: { climates: ["mild"] },
+    items: [
+      {
+        id: "evening-layer",
+        category: "clothing",
+        label: "One warm layer for the evening",
+        note: "Mild days still lose 8–10°C after dark.",
+      },
+      { id: "rain-jacket", category: "clothing", label: "Light rain jacket" },
+    ],
+  },
+  {
+    when: { climates: ["cold"] },
+    items: [
+      {
+        id: "thermals",
+        category: "clothing",
+        label: "Thermal base layers, top and bottom",
+      },
+      {
+        id: "insulated-jacket",
+        category: "clothing",
+        label: "Insulated jacket",
+        note: "Down packs smaller; synthetic keeps working when it's wet.",
+      },
+      {
+        id: "hat-gloves-scarf",
+        category: "clothing",
+        label: "Hat, gloves, and scarf",
+      },
+      {
+        id: "winter-boots",
+        category: "clothing",
+        label: "Waterproof boots with grip",
+      },
+      {
+        id: "moisturiser",
+        category: "toiletries",
+        label: "Heavy moisturiser and lip balm",
+        note: "Indoor heating dries skin faster than the cold outside does.",
+      },
+      { id: "hand-warmers", category: "gear", label: "Hand warmers" },
+    ],
+  },
+
+  // ------------------------------------------------------------ duration ---
+  {
+    when: { maxDays: 3 },
+    items: [
+      {
+        id: "one-bag",
+        category: "gear",
+        label: "One bag, cabin-sized",
+        note: "Three days genuinely fits. Checking a bag costs you an hour at both ends.",
+      },
+    ],
+  },
+  {
+    when: { minDays: 8 },
+    items: [
+      {
+        id: "laundry-plan",
+        category: "clothing",
+        label: "A laundry stop, planned in",
+        note: "The counts above cover two weeks with one wash. Packing more clothes is the wrong fix.",
+      },
+      {
+        id: "travel-detergent",
+        category: "toiletries",
+        label: "Travel detergent or laundry sheets",
+      },
+    ],
+  },
+  {
+    when: { minDays: 14 },
+    items: [
+      {
+        id: "grooming-extras",
+        category: "toiletries",
+        label: "Nail clippers and a small sewing kit",
+        note: "Two weeks is long enough for both to matter.",
+      },
+      {
+        id: "repeat-prescription",
+        category: "health",
+        label: "Check your prescriptions cover the whole trip",
+        note: "Plus a week. Refilling abroad ranges from expensive to impossible.",
+      },
+    ],
+  },
+
+  // --------------------------------------------------------------- flags ---
+  {
+    when: { carryOnOnly: true },
+    items: [
+      {
+        id: "liquids-bag",
+        category: "toiletries",
+        label: "Liquids in one clear resealable bag",
+        note: "100ml per container maximum, whatever the bottle is only part-full to.",
+      },
+      {
+        id: "solid-toiletries",
+        category: "toiletries",
+        label: "Solid swaps for your bulkiest liquids",
+        note: "Shampoo bar, toothpaste tabs, stick sunscreen — none of them count against the liquids bag.",
+      },
+      {
+        id: "cabin-dimensions",
+        category: "documents",
+        label: "Your airline's cabin bag dimensions, checked",
+        note: "They vary by several centimetres between carriers, and gate staff do measure.",
+      },
+      {
+        id: "wear-the-bulk",
+        category: "clothing",
+        label: "Wear your bulkiest jacket and shoes onto the plane",
+      },
+      {
+        id: "no-sharps",
+        category: "gear",
+        label: "Nothing sharp in the bag",
+        note: "Full-size scissors, loose razor blades, and multi-tools all get confiscated.",
+      },
+    ],
+  },
+  {
+    when: { checkedBag: true },
+    items: [
+      {
+        id: "carry-on-change",
+        category: "clothing",
+        label: "One full change of clothes in your carry-on",
+        note: "Covers the 24–48 hours a delayed bag typically takes to catch up.",
+      },
+      { id: "luggage-lock", category: "gear", label: "TSA-approved lock" },
+      {
+        id: "luggage-tag",
+        category: "gear",
+        label: "Luggage tag outside, contact details inside",
+        note: "Tags get torn off; the sheet of paper on top of your clothes doesn't.",
+      },
+      {
+        id: "bag-tracker",
+        category: "tech",
+        label: "A tracker in the bag",
+        note: "Airlines now act on a passenger showing them exactly which terminal the bag is in.",
+      },
+      {
+        id: "weigh-bag",
+        category: "gear",
+        label: "Weigh the bag at home",
+        note: "Excess baggage at the desk is priced to hurt.",
+      },
+    ],
+  },
+  {
+    when: { kids: true },
+    items: [
+      {
+        id: "kids-passports",
+        category: "documents",
+        label: "A passport for each child",
+        note: "Plus a consent letter if they're travelling without both parents — increasingly asked for.",
+      },
+      {
+        id: "kids-snacks",
+        category: "kids",
+        label: "More snacks than you think",
+        note: "Then the same again for the journey home.",
+      },
+      {
+        id: "kids-water",
+        category: "kids",
+        label: "Refillable water bottles",
+      },
+      {
+        id: "kids-change",
+        category: "kids",
+        label: "A change of clothes per child in the carry-on",
+        note: "And a spare top for whichever adult is holding them.",
+      },
+      {
+        id: "kids-wipes",
+        category: "kids",
+        label: "Wipes, and nappies plus half again",
+      },
+      {
+        id: "kids-medicine",
+        category: "kids",
+        label: "Children's paracetamol, ibuprofen, and a thermometer",
+        note: "Dosing by weight differs between countries; bring what you already know how to use.",
+      },
+      {
+        id: "kids-entertainment",
+        category: "kids",
+        label: "Downloaded shows and games, on a charged tablet",
+        note: "Downloaded. Plane Wi-Fi is not a plan.",
+      },
+      {
+        id: "kids-headphones",
+        category: "kids",
+        label: "Kid-sized volume-limited headphones",
+      },
+      {
+        id: "kids-comfort",
+        category: "kids",
+        label: "One comfort item each",
+        note: "The single item that cannot be replaced. Consider a spare of the crucial one.",
+      },
+      {
+        id: "kids-car-seat",
+        category: "kids",
+        label: "Car seat or booster, if you're renting a car",
+        note: "Rental seats are a lottery on both fit and cleanliness.",
+      },
+      {
+        id: "kids-sunscreen",
+        category: "kids",
+        label: "Kids' SPF 50 and sun hats",
+      },
+    ],
+  },
+];

--- a/src/data/packingList/types.ts
+++ b/src/data/packingList/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Types for the packing list generator.
+ *
+ * Kept in their own module so both the server-rendered curated pages and the
+ * client-side island import the same definitions — the two can never drift.
+ */
+
+export const TRIP_TYPES = [
+  "beach",
+  "city",
+  "hiking",
+  "business",
+  "ski",
+  "backpacking",
+] as const;
+export type TripType = (typeof TRIP_TYPES)[number];
+
+export const CLIMATES = ["hot", "tropical", "mild", "cold"] as const;
+export type Climate = (typeof CLIMATES)[number];
+
+export const CATEGORY_IDS = [
+  "documents",
+  "clothing",
+  "toiletries",
+  "health",
+  "tech",
+  "gear",
+  "kids",
+] as const;
+export type CategoryId = (typeof CATEGORY_IDS)[number];
+
+export interface PackingOptions {
+  type: TripType;
+  /** Nights away. Drives clothing quantities and the laundry threshold. */
+  days: number;
+  climate: Climate;
+  carryOnOnly: boolean;
+  checkedBag: boolean;
+  kids: boolean;
+}
+
+/** A single line on the finished list. */
+export interface PackingItem {
+  /** Stable across option changes, so checkbox state survives a re-generate. */
+  id: string;
+  label: string;
+  /** The reason it's on the list. Short — this is a checklist, not an essay. */
+  note?: string;
+  category: CategoryId;
+}
+
+/**
+ * An item as authored in the rules, before quantities are resolved. Label and
+ * note may both depend on the options — a count that scales with duration, or
+ * advice that only applies in the cold.
+ */
+export interface ItemSpec extends Omit<PackingItem, "label" | "note"> {
+  label: string | ((o: PackingOptions) => string);
+  note?: string | ((o: PackingOptions) => string | undefined);
+}
+
+/** Conditions under which a rule's items join the list. All must match. */
+export interface RuleCondition {
+  types?: readonly TripType[];
+  climates?: readonly Climate[];
+  minDays?: number;
+  maxDays?: number;
+  carryOnOnly?: boolean;
+  checkedBag?: boolean;
+  kids?: boolean;
+}
+
+export interface Rule {
+  when?: RuleCondition;
+  items: readonly ItemSpec[];
+}
+
+export interface PackingSection {
+  id: CategoryId;
+  title: string;
+  items: PackingItem[];
+}
+
+export const CATEGORY_TITLES: Record<CategoryId, string> = {
+  documents: "Documents & money",
+  clothing: "Clothing",
+  toiletries: "Toiletries",
+  health: "Health & medication",
+  tech: "Tech",
+  gear: "Gear & extras",
+  kids: "Travelling with kids",
+};
+
+export const TRIP_TYPE_LABELS: Record<TripType, string> = {
+  beach: "Beach holiday",
+  city: "City break",
+  hiking: "Hiking",
+  business: "Business trip",
+  ski: "Ski trip",
+  backpacking: "Backpacking",
+};
+
+export const CLIMATE_LABELS: Record<Climate, string> = {
+  hot: "Hot and dry",
+  tropical: "Hot and humid",
+  mild: "Mild",
+  cold: "Cold",
+};
+
+/** Durations offered in the hub. Curated pages may use any number. */
+export const DURATION_CHOICES = [2, 3, 4, 5, 7, 10, 14, 21] as const;
+
+export const DEFAULT_OPTIONS: PackingOptions = {
+  type: "city",
+  days: 7,
+  climate: "mild",
+  carryOnOnly: false,
+  checkedBag: true,
+  kids: false,
+};

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -19,6 +19,11 @@ interface Props {
   tags?: string[];
   bodyClass?: string;
   hideAppBanner?: boolean;
+  /**
+   * Trail below Home, for sections that aren't the blog. Omit and the layout
+   * builds the blog trail it was originally written for.
+   */
+  breadcrumbTrail?: { name: string; item: string }[];
 }
 
 const {
@@ -34,6 +39,7 @@ const {
   tags = [],
   bodyClass = "",
   hideAppBanner = false,
+  breadcrumbTrail,
 } = Astro.props;
 
 const appStoreData = (await fetchAppStoreData()) ?? fallbackAppStoreData;
@@ -74,28 +80,21 @@ const orgNode = {
   url: "https://www.12f.dk",
 };
 
-const breadcrumbItems = [
-  {
-    "@type": "ListItem",
-    position: 1,
-    name: "Home",
-    item: siteUrl,
-  },
-  {
-    "@type": "ListItem",
-    position: 2,
-    name: "Blog",
-    item: new URL("/blog/", Astro.site).href,
-  },
+const trail = breadcrumbTrail ?? [
+  { name: "Blog", item: new URL("/blog/", Astro.site).href },
+  ...(Astro.url.pathname === "/blog/" || Astro.url.pathname === "/blog"
+    ? []
+    : [{ name: title, item: canonicalURL.href }]),
 ];
-if (Astro.url.pathname !== "/blog/" && Astro.url.pathname !== "/blog") {
-  breadcrumbItems.push({
+const breadcrumbItems = [
+  { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+  ...trail.map((crumb, index) => ({
     "@type": "ListItem",
-    position: 3,
-    name: title,
-    item: canonicalURL.href,
-  });
-}
+    position: index + 2,
+    name: crumb.name,
+    item: crumb.item,
+  })),
+];
 const breadcrumbNode = {
   "@type": "BreadcrumbList",
   "@id": breadcrumbId,

--- a/src/modules/home/_components/packingTool/index.tsx
+++ b/src/modules/home/_components/packingTool/index.tsx
@@ -1,0 +1,78 @@
+import { useContext } from "react";
+import { motion } from "framer-motion";
+import { ConfigContext } from "../../../../utils/configContext";
+
+const POPULAR = [
+  { href: "/packing-list/carry-on-only-packing-list/", title: "Carry-on only" },
+  { href: "/packing-list/7-day-beach-trip-packing-list/", title: "7-day beach trip" },
+  { href: "/packing-list/what-to-pack-for-japan-in-winter/", title: "Japan in winter" },
+  { href: "/packing-list/3-day-business-trip-packing-list/", title: "3-day business trip" },
+  { href: "/packing-list/family-beach-holiday-packing-list/", title: "Beach with kids" },
+  { href: "/packing-list/week-long-ski-trip-packing-list/", title: "A week of skiing" },
+];
+
+/**
+ * The path in to /packing-list/ from the site's strongest page.
+ *
+ * English only: the tool ships in English (#57), and the localised homepages
+ * shouldn't send their visitors to a page they can't read.
+ */
+function PackingTool() {
+  const { locale } = useContext(ConfigContext)!;
+  if (locale && locale !== "en") return null;
+
+  return (
+    <section
+      id="packing-list-tool"
+      aria-labelledby="packing-tool-heading"
+      className="mx-auto max-w-screen-lg px-4 py-16 md:py-24"
+    >
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-60px" }}
+        transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+        className="rounded-box border border-base-300 bg-base-200/50 p-8 md:p-12"
+      >
+        <p className="m-0 flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-base-content/50">
+          <span className="inline-block h-0.5 w-8 bg-primary" />
+          Free tool — no install
+        </p>
+        <h2
+          id="packing-tool-heading"
+          className="mb-3 mt-5 text-3xl font-extrabold leading-[1.05] md:text-4xl"
+        >
+          Build your packing list right here
+        </h2>
+        <p className="m-0 max-w-2xl text-lg leading-relaxed text-base-content/70">
+          Pick the trip, the length and the weather, and get a categorised
+          checklist you can tick off, print or download. No account, no email
+          address, nothing to install.
+        </p>
+
+        <a
+          href="/packing-list/"
+          data-umami-event="home-packing-list-cta"
+          className="btn mt-7 border-none bg-primary text-primary-content shadow-md shadow-primary/30 hover:brightness-110"
+        >
+          Open the packing list generator
+        </a>
+
+        <ul className="mt-8 flex list-none flex-wrap gap-2 p-0">
+          {POPULAR.map((item) => (
+            <li key={item.href} className="m-0">
+              <a
+                href={item.href}
+                className="inline-block rounded-full border border-base-300 bg-base-100 px-4 py-2 text-sm font-medium transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </motion.div>
+    </section>
+  );
+}
+
+export default PackingTool;

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -19,6 +19,7 @@ import Comparison from "./_components/comparison";
 import AppStoreReviews from "./_components/appStoreReviews";
 import Pricing from "./_components/pricing";
 import FromTheBlog from "./_components/fromTheBlog";
+import PackingTool from "./_components/packingTool";
 
 interface Props {
   config: TemplateConfig;
@@ -49,6 +50,7 @@ function Home({ config, posts = [], reviews = [] }: Props) {
         />
         <AppStoreReviews reviews={reviews} />
         <Pricing />
+        <PackingTool />
         <FromTheBlog posts={posts} />
         <Faq />
         <AppBanner />

--- a/src/modules/packingList/_components/RelatedLists.astro
+++ b/src/modules/packingList/_components/RelatedLists.astro
@@ -1,0 +1,37 @@
+---
+import { CURATED_PAGES } from "../../../data/packingList/pages";
+
+interface Props {
+  /** Slug of the page doing the linking, so it doesn't link to itself. */
+  currentSlug?: string;
+  heading?: string;
+  limit?: number;
+}
+
+const { currentSlug, heading = "Ready-made lists", limit } = Astro.props;
+
+const pages = CURATED_PAGES.filter((page) => page.slug !== currentSlug);
+const shown = limit ? pages.slice(0, limit) : pages;
+---
+
+<section aria-labelledby="related-lists" class="mt-16">
+  <h2 id="related-lists" class="mb-2 text-2xl font-bold">{heading}</h2>
+  <p class="mb-6 max-w-2xl text-base-content/70">
+    Each one is a full list with advice specific to that trip — and the
+    generator underneath it, so you can adjust it to yours.
+  </p>
+  <ul class="grid list-none grid-cols-1 gap-3 p-0 sm:grid-cols-2 lg:grid-cols-3">
+    {
+      shown.map((page) => (
+        <li class="m-0">
+          <a
+            href={`/packing-list/${page.slug}/`}
+            class="flex h-full items-center rounded-box border border-base-300 bg-base-100 px-4 py-3 text-sm font-medium leading-snug transition-colors hover:border-primary/40 hover:text-primary"
+          >
+            {page.h1}
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</section>

--- a/src/modules/packingList/_components/generator.tsx
+++ b/src/modules/packingList/_components/generator.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildPackingList,
+  countItems,
+  describeOptions,
+  optionsFromQuery,
+  optionsToQuery,
+  sectionsToText,
+  CLIMATES,
+  CLIMATE_LABELS,
+  DURATION_CHOICES,
+  TRIP_TYPES,
+  TRIP_TYPE_LABELS,
+  type Climate,
+  type PackingItem,
+  type PackingOptions,
+  type TripType,
+} from "../../../data/packingList";
+import ListView from "./listView";
+
+interface Props {
+  /** Server-rendered configuration. The URL query overrides it after mount. */
+  initialOptions: PackingOptions;
+  /** Scenario-specific items from a curated page. */
+  extras?: PackingItem[];
+  /** Curated pages already have their own H1/intro and hide the controls' heading. */
+  heading?: string;
+  /** Where the App Store CTA points. Optional, as it is in the site config. */
+  appStoreLink?: string;
+  storageKey: string;
+}
+
+type Action = "copy" | "download" | null;
+
+const TOGGLES: { key: "carryOnOnly" | "checkedBag" | "kids"; label: string }[] = [
+  { key: "carryOnOnly", label: "Carry-on only" },
+  { key: "checkedBag", label: "Checked bag" },
+  { key: "kids", label: "Travelling with kids" },
+];
+
+function Generator({
+  initialOptions,
+  extras = [],
+  heading,
+  appStoreLink,
+  storageKey,
+}: Props) {
+  const [options, setOptions] = useState<PackingOptions>(initialOptions);
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [confirmation, setConfirmation] = useState<Action>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const confirmationTimer = useRef<number>();
+
+  // Read shared state out of the URL and any previous progress out of storage.
+  // Deliberately in an effect rather than during render: the server has no
+  // access to either, and reading them during render would make the first
+  // client render disagree with the HTML it is hydrating.
+  useEffect(() => {
+    setHydrated(true);
+    const query = window.location.search;
+    if (query.length > 1) {
+      setOptions(optionsFromQuery(query, initialOptions));
+    }
+    try {
+      const saved = window.localStorage.getItem(storageKey);
+      if (saved) setChecked(JSON.parse(saved));
+    } catch {
+      // Private browsing, or someone hand-edited the value. Start fresh.
+    }
+    // initialOptions is a build-time constant for this page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(checked));
+    } catch {
+      // Storage full or blocked — the list still works, it just won't persist.
+    }
+  }, [checked, hydrated, storageKey]);
+
+  const sections = useMemo(
+    () => buildPackingList(options, extras),
+    [options, extras],
+  );
+  const total = countItems(sections);
+  const packed = sections.reduce(
+    (sum, section) =>
+      sum + section.items.filter((item) => checked[item.id]).length,
+    0,
+  );
+
+  const summary = describeOptions(options);
+  const listTitle = heading ?? `Packing list — ${summary}`;
+
+  const update = useCallback(
+    (patch: Partial<PackingOptions>) => {
+      setOptions((current) => {
+        const next = { ...current, ...patch };
+        // Carry-on only and a checked bag contradict each other; whichever the
+        // visitor just touched wins, so the toggles never both read as true.
+        if (patch.carryOnOnly) next.checkedBag = false;
+        if (patch.checkedBag) next.carryOnOnly = false;
+        // Shareable: the configuration lives in the query string. Written with
+        // replaceState so the canonical URL stays clean until something changes.
+        if (typeof window !== "undefined") {
+          window.history.replaceState(
+            null,
+            "",
+            `${window.location.pathname}?${optionsToQuery(next)}`,
+          );
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const toggle = useCallback((id: string) => {
+    setChecked((current) => ({ ...current, [id]: !current[id] }));
+  }, []);
+
+  const flash = (action: Action) => {
+    setConfirmation(action);
+    window.clearTimeout(confirmationTimer.current);
+    confirmationTimer.current = window.setTimeout(
+      () => setConfirmation(null),
+      2500,
+    );
+  };
+  useEffect(() => () => window.clearTimeout(confirmationTimer.current), []);
+
+  const asText = () => sectionsToText(sections, listTitle);
+
+  const copy = async () => {
+    const text = asText();
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard API needs a secure context and a permission the browser may
+      // withhold. The old execCommand path still works where it doesn't.
+      const area = document.createElement("textarea");
+      area.value = text;
+      area.style.position = "fixed";
+      area.style.opacity = "0";
+      document.body.appendChild(area);
+      area.select();
+      document.execCommand("copy");
+      document.body.removeChild(area);
+    }
+    flash("copy");
+  };
+
+  const download = () => {
+    const blob = new Blob([asText()], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `packing-list-${options.type}-${options.days}-day.txt`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    flash("download");
+  };
+
+  const reset = () => setChecked({});
+
+  return (
+    <div>
+      <form
+        className="packing-list-controls rounded-box border border-base-300 bg-base-200/60 p-5 sm:p-6"
+        onSubmit={(event) => event.preventDefault()}
+        aria-label="Packing list options"
+      >
+        <div className="grid gap-5 sm:grid-cols-3">
+          <div>
+            <label
+              htmlFor="trip-type"
+              className="mb-1.5 block text-sm font-semibold"
+            >
+              Trip type
+            </label>
+            <select
+              id="trip-type"
+              className="select select-bordered w-full bg-base-100"
+              value={options.type}
+              onChange={(event) =>
+                update({ type: event.target.value as TripType })
+              }
+            >
+              {TRIP_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {TRIP_TYPE_LABELS[type]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="trip-days"
+              className="mb-1.5 block text-sm font-semibold"
+            >
+              How long
+            </label>
+            <select
+              id="trip-days"
+              className="select select-bordered w-full bg-base-100"
+              value={options.days}
+              onChange={(event) =>
+                update({ days: Number(event.target.value) })
+              }
+            >
+              {DURATION_CHOICES.map((days) => (
+                <option key={days} value={days}>
+                  {days} days
+                </option>
+              ))}
+              {!DURATION_CHOICES.includes(
+                options.days as (typeof DURATION_CHOICES)[number],
+              ) && (
+                <option value={options.days}>{options.days} days</option>
+              )}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="trip-climate"
+              className="mb-1.5 block text-sm font-semibold"
+            >
+              Climate
+            </label>
+            <select
+              id="trip-climate"
+              className="select select-bordered w-full bg-base-100"
+              value={options.climate}
+              onChange={(event) =>
+                update({ climate: event.target.value as Climate })
+              }
+            >
+              {CLIMATES.map((climate) => (
+                <option key={climate} value={climate}>
+                  {CLIMATE_LABELS[climate]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <fieldset className="mt-5">
+          <legend className="mb-2 text-sm font-semibold">Also</legend>
+          <div className="flex flex-wrap gap-x-6 gap-y-3">
+            {TOGGLES.map(({ key, label }) => (
+              <label
+                key={key}
+                htmlFor={`opt-${key}`}
+                className="flex cursor-pointer items-center gap-2 text-sm font-medium"
+              >
+                <input
+                  type="checkbox"
+                  id={`opt-${key}`}
+                  className="checkbox checkbox-primary checkbox-sm"
+                  checked={options[key]}
+                  onChange={(event) =>
+                    update({ [key]: event.target.checked } as Partial<PackingOptions>)
+                  }
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      </form>
+
+      <div className="packing-list-summary mt-8 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="m-0 text-2xl font-bold">Your list</h2>
+          <p className="m-0 mt-1 text-base-content/70">
+            {/* first-letter, not `capitalize` — that title-cases every word. */}
+            <span className="inline-block first-letter:uppercase">{summary}</span> ·{" "}
+            <span aria-live="polite">
+              {packed} of {total} packed
+            </span>
+          </p>
+        </div>
+        <div className="packing-list-actions flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="btn btn-sm border-base-300 bg-base-100 hover:bg-base-200"
+            onClick={() => window.print()}
+          >
+            Print
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm border-base-300 bg-base-100 hover:bg-base-200"
+            onClick={copy}
+          >
+            {confirmation === "copy" ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm border-base-300 bg-base-100 hover:bg-base-200"
+            onClick={download}
+          >
+            {confirmation === "download" ? "Downloaded" : "Download .txt"}
+          </button>
+          {packed > 0 && (
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={reset}
+            >
+              Clear ticks
+            </button>
+          )}
+        </div>
+      </div>
+
+      <p className="sr-only" role="status">
+        {confirmation === "copy" && "List copied to the clipboard."}
+        {confirmation === "download" && "List downloaded as a text file."}
+      </p>
+
+      {/* Paper only — the printed sheet still needs to say what it is. */}
+      <h2 className="packing-list-print-title">{listTitle}</h2>
+      <p className="packing-list-print-meta">
+        {total} items · {summary} · travel-stories.12f.dk/packing-list/
+      </p>
+
+      <div className="mt-6">
+        <ListView sections={sections} checked={checked} onToggle={toggle} />
+      </div>
+
+      {appStoreLink && (
+      <aside className="packing-list-cta mt-4 rounded-box border border-primary/20 bg-primary/5 p-6 sm:p-8">
+        <h2 className="m-0 text-xl font-bold sm:text-2xl">
+          Take this list with you
+        </h2>
+        <p className="mb-5 mt-2 max-w-2xl text-base-content/75">
+          A printed list stays at home in the drawer. Travel Stories keeps the
+          same checklist on your phone next to the itinerary, the bookings and
+          the budget — offline, free, and reusable on the next trip so you never
+          start from a blank page again.
+        </p>
+        <a
+          href={appStoreLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-umami-event="packing-list-app-cta"
+          className="btn border-none bg-primary text-primary-content shadow-md shadow-primary/30 hover:brightness-110"
+        >
+          Open this list in Travel Stories — free
+        </a>
+      </aside>
+      )}
+    </div>
+  );
+}
+
+export default Generator;

--- a/src/modules/packingList/_components/listView.tsx
+++ b/src/modules/packingList/_components/listView.tsx
@@ -1,0 +1,76 @@
+import type { PackingSection } from "../../../data/packingList";
+
+interface Props {
+  sections: PackingSection[];
+  checked: Record<string, boolean>;
+  onToggle: (id: string) => void;
+}
+
+/**
+ * The list itself.
+ *
+ * Real <input type="checkbox"> elements with real <label>s — not divs with
+ * click handlers — so the list is keyboard-operable and screen readers announce
+ * the checked state without any ARIA of our own.
+ */
+function ListView({ sections, checked, onToggle }: Props) {
+  return (
+    <div className="packing-list-columns">
+      {sections.map((section) => (
+        <section
+          key={section.id}
+          aria-labelledby={`section-${section.id}`}
+          className="packing-list-section mb-6 break-inside-avoid rounded-box border border-base-300 bg-base-100 p-5 sm:p-6"
+        >
+          <h3
+            id={`section-${section.id}`}
+            className="mb-3 flex items-baseline gap-2 text-lg font-bold"
+          >
+            {section.title}
+            <span className="text-sm font-normal text-base-content/50">
+              {section.items.length}
+            </span>
+          </h3>
+          <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+            {section.items.map((item) => {
+              const id = `pack-${item.id}`;
+              const isChecked = Boolean(checked[item.id]);
+              return (
+                <li key={item.id} className="m-0 p-0">
+                  <label
+                    htmlFor={id}
+                    className="flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-base-200"
+                  >
+                    <input
+                      type="checkbox"
+                      id={id}
+                      className="checkbox checkbox-primary checkbox-sm mt-0.5 shrink-0"
+                      checked={isChecked}
+                      onChange={() => onToggle(item.id)}
+                    />
+                    <span className="min-w-0">
+                      <span
+                        className={`block font-medium leading-snug ${
+                          isChecked ? "text-base-content/40 line-through" : ""
+                        }`}
+                      >
+                        {item.label}
+                      </span>
+                      {item.note && (
+                        <span className="packing-list-note mt-0.5 block text-sm leading-snug text-base-content/60">
+                          {item.note}
+                        </span>
+                      )}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default ListView;

--- a/src/modules/packingList/index.tsx
+++ b/src/modules/packingList/index.tsx
@@ -1,0 +1,8 @@
+/**
+ * Island entry point for the packing list generator.
+ *
+ * The surrounding page — headings, advice, cross-links — stays static Astro so
+ * crawlers get the content without executing anything. Only the part that has
+ * to respond to a click ships as JavaScript.
+ */
+export { default } from "./_components/generator";

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -39,6 +39,13 @@ const formatDate = (d: Date) =>
         Practical guides on planning, packing, and budgeting your trips — and on
         holding onto them afterwards. Real checklists, real methods, no fluff.
       </p>
+      <p class="mt-5 text-base text-base-content/70">
+        Looking for a checklist rather than an article? The{" "}
+        <a href="/packing-list/" class="link link-primary font-semibold">
+          packing list generator
+        </a>{" "}
+        builds one for your trip — free, no sign-up, printable.
+      </p>
     </header>
 
     {

--- a/src/pages/packing-list/[slug].astro
+++ b/src/pages/packing-list/[slug].astro
@@ -1,0 +1,135 @@
+---
+import { getCollection } from "astro:content";
+import BlogLayout from "../../layouts/BlogLayout.astro";
+import RelatedLists from "../../modules/packingList/_components/RelatedLists.astro";
+import PackingListGenerator from "../../modules/packingList";
+import defaultTemplateConfig from "../../utils/config";
+import { CURATED_PAGES, type CuratedPage } from "../../data/packingList/pages";
+import { buildPackingList, countItems, describeOptions } from "../../data/packingList";
+
+export async function getStaticPaths() {
+  return CURATED_PAGES.map((page) => ({
+    params: { slug: page.slug },
+    props: { page },
+  }));
+}
+
+const { page } = Astro.props as { page: CuratedPage };
+
+const canonicalPath = `/packing-list/${page.slug}/`;
+const canonicalURL = new URL(canonicalPath, Astro.site);
+
+// The list is generated here, at build time, and rendered into the HTML — the
+// island re-derives the identical one on hydration from the same pure function.
+const sections = buildPackingList(page.options, page.extras);
+const total = countItems(sections);
+
+const posts = await getCollection("blog", ({ data }) => !data.draft);
+const related = page.related
+  .map((slug) => posts.find((post) => post.slug === slug))
+  .filter((post): post is (typeof posts)[number] => Boolean(post));
+
+const itemListNode = {
+  "@type": "ItemList",
+  "@id": `${canonicalURL.href}#list`,
+  name: page.h1,
+  description: page.description,
+  numberOfItems: total,
+  itemListOrder: "https://schema.org/ItemListOrderAscending",
+  itemListElement: sections
+    .flatMap((section) =>
+      section.items.map((item) => ({
+        "@type": "ListItem",
+        name: item.label,
+        ...(item.note ? { description: item.note } : {}),
+      })),
+    )
+    .map((item, index) => ({ ...item, position: index + 1 })),
+};
+---
+
+<BlogLayout
+  title={`${page.title} | Travel Stories`}
+  description={page.description}
+  canonicalPath={canonicalPath}
+  extraGraphNodes={[itemListNode]}
+  hideAppBanner={true}
+  bodyClass="packing-page"
+  breadcrumbTrail={[
+    { name: "Packing lists", item: new URL("/packing-list/", Astro.site).href },
+    { name: page.h1, item: canonicalURL.href },
+  ]}
+>
+  <main id="main" class="mx-auto max-w-screen-lg px-4 py-12 md:py-16">
+    <nav aria-label="Breadcrumb" class="mb-6 text-sm text-base-content/60">
+      <a href="/" class="hover:text-primary">Home</a>
+      <span class="mx-1.5" aria-hidden="true">/</span>
+      <a href="/packing-list/" class="hover:text-primary">Packing lists</a>
+    </nav>
+
+    <header class="mb-10 max-w-3xl">
+      <h1 class="mb-4 text-4xl font-extrabold leading-[1.08] md:text-5xl">
+        {page.h1}
+      </h1>
+      <p class="text-lg leading-relaxed text-base-content/80" data-speakable>
+        {page.lede}
+      </p>
+      <p class="mt-4 text-sm text-base-content/60">
+        {total} items · {describeOptions(page.options)} · tick them off, print,
+        or adjust the list to your trip below
+      </p>
+    </header>
+
+    <section class="mb-12 max-w-3xl" aria-labelledby="advice">
+      <h2 id="advice" class="sr-only">What's different about this trip</h2>
+      <div class="space-y-8">
+        {
+          page.advice.map((block) => (
+            <div>
+              <h3 class="mb-2 text-xl font-bold">{block.heading}</h3>
+              <p class="m-0 leading-relaxed text-base-content/80">{block.body}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <div class="packing-list-root">
+      <PackingListGenerator
+        client:idle
+        initialOptions={page.options}
+        extras={page.extras}
+        heading={page.h1}
+        appStoreLink={defaultTemplateConfig.appStoreLink}
+        storageKey={`packing-list:${page.slug}`}
+      />
+    </div>
+
+    {
+      related.length > 0 && (
+        <section class="mt-16 max-w-3xl" aria-labelledby="read-more">
+          <h2 id="read-more" class="mb-4 text-2xl font-bold">
+            Read more
+          </h2>
+          <ul class="m-0 list-none space-y-3 p-0">
+            {related.map((post) => (
+              <li class="m-0">
+                <a
+                  href={`/blog/${post.slug}/`}
+                  class="link link-primary font-semibold"
+                >
+                  {post.data.title}
+                </a>
+                <span class="block text-sm text-base-content/65">
+                  {post.data.description}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )
+    }
+
+    <RelatedLists currentSlug={page.slug} heading="Other packing lists" />
+  </main>
+</BlogLayout>

--- a/src/pages/packing-list/index.astro
+++ b/src/pages/packing-list/index.astro
@@ -1,0 +1,164 @@
+---
+import BlogLayout from "../../layouts/BlogLayout.astro";
+import FaqSection from "../../components/blog/FaqSection.astro";
+import RelatedLists from "../../modules/packingList/_components/RelatedLists.astro";
+import PackingListGenerator from "../../modules/packingList";
+import defaultTemplateConfig from "../../utils/config";
+import { buildPackingList, countItems, DEFAULT_OPTIONS } from "../../data/packingList";
+
+const canonicalPath = "/packing-list/";
+const canonicalURL = new URL(canonicalPath, Astro.site);
+
+// Rendered here as well as inside the island, so the ItemList schema and the
+// "N items" claims come from the same generator the visitor is looking at.
+const sections = buildPackingList(DEFAULT_OPTIONS);
+const total = countItems(sections);
+
+const itemListNode = {
+  "@type": "ItemList",
+  "@id": `${canonicalURL.href}#list`,
+  name: "Packing list generator",
+  description:
+    "A categorised travel packing checklist generated from trip type, duration, climate, and whether you're travelling carry-on only or with children.",
+  numberOfItems: total,
+  itemListOrder: "https://schema.org/ItemListOrderAscending",
+  itemListElement: sections.flatMap((section) =>
+    section.items.map((item) => ({
+      "@type": "ListItem",
+      name: item.label,
+      ...(item.note ? { description: item.note } : {}),
+    })),
+  ).map((item, index) => ({ ...item, position: index + 1 })),
+};
+
+const faq = [
+  {
+    question: "Do I need to sign up to use the packing list generator?",
+    answer:
+      "No. There is no account, no email address, and no app install required. Pick your trip type, duration and climate, and the list appears immediately — you can print it, copy it, or download it as a text file straight away.",
+  },
+  {
+    question: "How many clothes should I pack per day?",
+    answer:
+      "Fewer than one outfit per day. The generator uses roughly 0.7 tops per day up to a cap of seven, one bottom per two days up to four, and underwear and socks for each day plus one spare. Past about eight days it stops adding clothes and adds a laundry stop instead, because packing two weeks of outfits is heavier than washing once.",
+  },
+  {
+    question: "What should never go in checked luggage?",
+    answer:
+      "Passport and documents, all medication, electronics and chargers, valuables, and one full change of clothes. Those are the things you cannot quickly replace at your destination, and a delayed bag typically takes 24 to 48 hours to catch up with you.",
+  },
+  {
+    question: "Can I share the list I have configured?",
+    answer:
+      "Yes. Your choices are stored in the page's web address, so copying the URL from your browser and sending it to someone opens exactly the same list for them. The items you tick off are saved in your own browser only, and are not part of the shared link.",
+  },
+  {
+    question: "How much sunscreen should I take?",
+    answer:
+      "A full-body application for one adult is about 30 to 35ml. Applied twice a day for a week, that is roughly 500ml per person — around five standard travel bottles. Running out mid-trip is one of the most common packing miscalculations.",
+  },
+];
+
+const faqNode = {
+  "@type": "FAQPage",
+  "@id": `${canonicalURL.href}#faq`,
+  mainEntity: faq.map((item) => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: { "@type": "Answer", text: item.answer },
+  })),
+};
+
+const webAppNode = {
+  "@type": "WebApplication",
+  "@id": `${canonicalURL.href}#tool`,
+  name: "Packing List Generator",
+  url: canonicalURL.href,
+  applicationCategory: "TravelApplication",
+  browserRequirements: "Requires JavaScript for the interactive options.",
+  operatingSystem: "Any",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  isPartOf: { "@id": `${Astro.site?.href ?? ""}#website` },
+};
+---
+
+<BlogLayout
+  title="Packing List Generator — Build a Custom Travel Checklist | Travel Stories"
+  description="Free packing list generator. Choose your trip type, length and climate and get a categorised checklist you can tick off, print, copy or download. No sign-up, no install."
+  canonicalPath={canonicalPath}
+  extraGraphNodes={[webAppNode, itemListNode, faqNode]}
+  hideAppBanner={true}
+  bodyClass="packing-page"
+  breadcrumbTrail={[{ name: "Packing lists", item: canonicalURL.href }]}
+>
+  <main id="main" class="mx-auto max-w-screen-lg px-4 py-12 md:py-16">
+    <nav aria-label="Breadcrumb" class="mb-6 text-sm text-base-content/60">
+      <a href="/" class="hover:text-primary">Home</a>
+      <span class="mx-1.5" aria-hidden="true">/</span>
+      <span>Packing lists</span>
+    </nav>
+
+    <header class="mb-10 max-w-3xl">
+      <p class="m-0 flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-base-content/50">
+        <span class="inline-block h-0.5 w-8 bg-primary"></span>
+        Free tool
+      </p>
+      <h1 class="mb-4 mt-5 text-4xl font-extrabold leading-[1.05] md:text-5xl">
+        Packing list generator
+      </h1>
+      <p class="text-lg leading-relaxed text-base-content/75" data-speakable>
+        Choose the kind of trip, how long you're going, and what the weather
+        will do. You get a categorised checklist you can tick off, print, copy,
+        or download — no account, no email address, no install.
+      </p>
+    </header>
+
+    <div class="packing-list-root">
+      <PackingListGenerator
+        client:idle
+        initialOptions={DEFAULT_OPTIONS}
+        appStoreLink={defaultTemplateConfig.appStoreLink}
+        storageKey="packing-list:hub"
+      />
+    </div>
+
+    <section class="mt-16 max-w-3xl" aria-labelledby="how-it-works">
+      <h2 id="how-it-works" class="mb-4 text-2xl font-bold">
+        How the list is put together
+      </h2>
+      <div class="space-y-4 text-base-content/80">
+        <p class="m-0">
+          Every list starts from the same base: the documents, medication, tech
+          and clothing that no trip works without. On top of that go three sets
+          of modifiers — one for the kind of trip, one for the climate, and one
+          for the length — plus whatever the carry-on, checked bag and children
+          toggles imply.
+        </p>
+        <p class="m-0">
+          Quantities scale with duration rather than being fixed, and they stop
+          scaling at about a week. Beyond that the list adds a laundry stop
+          instead of more clothes, because the counts already cover a fortnight
+          with one wash and carrying fourteen outfits is the more expensive way
+          to solve it.
+        </p>
+        <p class="m-0">
+          Notes explain why an item is there. That's deliberate: a checklist you
+          can argue with is one you'll actually cut things from, and cutting is
+          the part of packing that most people find hardest.
+        </p>
+        <p class="m-0">
+          If you'd rather read the reasoning at length than tick a list, the{" "}
+          <a href="/blog/packing-list-for-international-travel/" class="link link-primary">
+            complete guide to packing for international travel
+          </a>{" "}
+          covers the clothing formula, what to leave at home, and the
+          pre-departure routine in full.
+        </p>
+      </div>
+    </section>
+
+    <RelatedLists heading="Ready-made lists" />
+
+    <FaqSection items={faq} />
+  </main>
+</BlogLayout>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -108,6 +108,122 @@ details > summary::-webkit-details-marker {
   to { opacity: 1; transform: translateY(0); }
 }
 
+/* ---------------------------------------------------------------------------
+   Packing list generator (/packing-list/)
+   --------------------------------------------------------------------------- */
+
+/* Multi-column so a 70-item list doesn't become a single endless strip. Each
+   section is break-inside-avoid, so categories stay whole. */
+.packing-list-columns {
+  column-gap: 1.5rem;
+}
+@media (min-width: 768px) {
+  .packing-list-columns {
+    column-count: 2;
+  }
+}
+
+/* daisyUI derives checkbox radius from --rounded-btn (0.75rem in this theme),
+   which at 16px makes them read as radio buttons — "pick one" on a list whose
+   whole point is picking many. Square them off. */
+.packing-list-section .checkbox,
+.packing-list-controls .checkbox {
+  border-radius: 0.25rem;
+}
+
+/* Only ever visible on paper. */
+.packing-list-print-title,
+.packing-list-print-meta {
+  display: none;
+}
+
+/* The printed list is the deliverable: one clean document, no site chrome, no
+   controls, no calls to action — just the categories and the boxes to tick. */
+@media print {
+  body.packing-page {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  /* Everything outside the list: navbar, footer, sticky bar, breadcrumbs,
+     advice, cross-links, FAQ. */
+  body.packing-page > *:not(main),
+  body.packing-page main > *:not(.packing-list-root),
+  body.packing-page .packing-list-controls,
+  body.packing-page .packing-list-summary,
+  body.packing-page .packing-list-cta {
+    display: none !important;
+  }
+
+  body.packing-page main {
+    max-width: none;
+    padding: 0;
+  }
+
+  .packing-list-print-title {
+    display: block;
+    margin: 0 0 0.25rem;
+    font-size: 15pt;
+    font-weight: 700;
+  }
+  .packing-list-print-meta {
+    display: block;
+    margin: 0 0 0.75rem;
+    font-size: 8pt;
+    color: #555;
+  }
+
+  .packing-list-columns {
+    column-count: 2;
+    column-gap: 1.25rem;
+  }
+
+  .packing-list-section {
+    margin: 0 0 0.6rem !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: none !important;
+    break-inside: avoid;
+  }
+  .packing-list-section h3 {
+    margin: 0 0 0.2rem;
+    font-size: 9.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid #999;
+  }
+  .packing-list-section label {
+    padding: 0.05rem 0 !important;
+    gap: 0.3rem !important;
+    font-size: 8.5pt;
+    line-height: 1.25;
+    break-inside: avoid;
+  }
+  .packing-list-section input[type="checkbox"] {
+    width: 8pt;
+    height: 8pt;
+    min-width: 8pt;
+    border: 0.7pt solid #000;
+    border-radius: 1pt;
+    -webkit-appearance: none;
+    appearance: none;
+    /* Ticked items still print as ticked — you're mid-pack, not starting over. */
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+  .packing-list-section input[type="checkbox"]:checked {
+    background: #000;
+  }
+  /* Notes are the reasoning; on paper the item names have to fit. */
+  .packing-list-note {
+    display: none !important;
+  }
+
+  @page {
+    margin: 12mm;
+  }
+}
+
 /* Clean, modern body styling */
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
Closes #57.

## What this is

`/packing-list/` — a packing list generator that works with no account, no email gate and no install — plus 26 curated, statically-rendered pages beneath it.

The reasoning from the issue holds: every existing page here is a marketing page, so it can convert traffic but never create it. This is the first surface built for queries typed by people who don't know the app exists.

## Structure

| | |
|---|---|
| `src/data/packingList/` | One typed source of truth. `types.ts`, `rules.ts` (base + trip-type + climate + duration + flag modifiers), `generate.ts` (pure `buildPackingList()`, URL codec, text export), `pages.ts` (curated copy). |
| `src/modules/packingList/` | The React island and `ListView`, plus the shared `RelatedLists.astro`. |
| `src/pages/packing-list/` | `index.astro` (hub) and `[slug].astro` (`getStaticPaths()` over the curated set). |

`pages.ts` is imported only by `.astro` files, so 26 pages of prose never reach the browser bundle.

## Decisions worth flagging

**Curated, not permuted.** 6 types × 8 durations × 4 climates × 3 flags is 768 combinations. Shipping those as pages is the doorway-page pattern, so the 26 are hand-picked to ones where the advice is actually different — Japan-in-winter carries shoe-removal, cash-only counters and takkyubin; a generic cold-weather list can't.

**Static first.** The list is in the HTML before hydration. The island is `client:idle` and reads the URL and localStorage in an effect, so the first client render agrees with the markup it's hydrating.

**No gate.** Value first, app link second — a tool behind a form is just another marketing page.

**Dedup semantics.** Rules are first-wins, so a trip-type note beats the generic climate one; a curated page's own items override in place instead of appearing twice further down. Two real bugs surfaced during testing and are fixed: `Hand warmers` appeared twice on the Japan page, and cold trips listed generic socks *and* wool socks — 13 pairs for 10 days. An audit script now confirms zero duplicate ids or duplicate item text across all 26 pages and all 768 option combinations.

## Verification

- `pnpm build` clean — 56 pages, 27 new. `astro check`: 0 errors, 0 warnings.
- Docker dev server + agent-browser: options, URL round-trip (`?type=beach&days=14&climate=tropical&kids=1` hydrates correctly), ticking, per-page localStorage persistence across reload, `.txt` download content, dark mode, 390px mobile. No console errors.
- Print renders as **one page** (verified via PDF): chrome, controls, CTA and notes dropped, two columns, ticked items still ticked.
- JSON-LD parses on every page; `ItemList` / `WebApplication` / `FAQPage` are folded into the single consolidated `@graph` (#24), not added as separate scripts.
- Present in `sitemap-index.xml` — hub at priority 0.8, curated pages at 0.7.
- No title or H1 collision with `packing-list-for-international-travel`; canonicals self-referencing.
- The 11 localised homepages are untouched: the homepage link is gated to `locale === "en"`, verified 0 links in each of the 11 builds.

## Note for the reviewer

Docker's Alpine image can't run `pnpm build` — `@resvg/resvg-js` isn't installed there at all, so `src/pages/og-image.png.ts` fails to resolve. Pre-existing and unrelated to this branch, but it means the production build had to be verified natively; the dev server and browser testing ran in Docker as normal. Worth its own issue.

## Dependency

The App Store CTA ships with the current clean link. **Attribution tokens (`pt`/`ct`) still need wiring via #52** once the ASC provider token exists — without them, installs referred from these pages keep landing in the Discovery report's "search" row instead of "App referrer", which is the row that makes this work measurable.

Baseline to measure against is July 2026: Web referrer = 6 page views, App referrer = 0. Give it 8–12 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01486FDB6WBDqapdYhBvuVKs