### PR TITLE
Link the packing list from the navbar and footer (English only)

### DIFF
--- a/src/i18n/translation.ts
+++ b/src/i18n/translation.ts
@@ -53,9 +53,13 @@ export function applyTranslation(
   // "/#anchor" links must stay on the localized homepage, not jump to "/".
   const localizeHref = (href: string) =>
     href.startsWith("/#") ? `${homeHref}${href.slice(1)}` : href;
+  // English-only links (the packing list tool, #57) are dropped before the
+  // positional zip below — otherwise they'd shift every t.nav.links index and
+  // hand each remaining item its neighbour's translation.
+  const navLinks = base.topNavbar.links.filter((link) => !link.enOnly);
   // Footer nav shares the navbar's titles — translate by href lookup.
   const navTitleByHref = new Map(
-    base.topNavbar.links.map((link, i) => [link.href, t.nav.links[i]]),
+    navLinks.map((link, i) => [link.href, t.nav.links[i]]),
   );
   return {
     ...base,
@@ -67,7 +71,7 @@ export function applyTranslation(
     topNavbar: {
       ...base.topNavbar,
       cta: t.nav.cta,
-      links: base.topNavbar.links.map((link, i) => ({
+      links: navLinks.map((link, i) => ({
         ...link,
         href: localizeHref(link.href),
         title: t.nav.links[i] ?? link.title,
@@ -75,7 +79,7 @@ export function applyTranslation(
     },
     footer: {
       ...base.footer,
-      links: base.footer.links.map((link) => ({
+      links: base.footer.links.filter((link) => !link.enOnly).map((link) => ({
         ...link,
         href: localizeHref(link.href),
         title: navTitleByHref.get(link.href) ?? link.title,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -49,6 +49,7 @@ const templateConfig: TemplateConfig = {
     links: [
       { href: "/#features", title: "Features" },
       { href: "/#how-it-works", title: "How it works" },
+      { href: "/packing-list/", title: "Packing list", enOnly: true },
       { href: "/#faq", title: "FAQ" },
       { href: "/blog/", title: "Blog" },
     ],
@@ -61,6 +62,7 @@ const templateConfig: TemplateConfig = {
     links: [
       { href: "/#features", title: "Features" },
       { href: "/#how-it-works", title: "How it works" },
+      { href: "/packing-list/", title: "Packing list", enOnly: true },
       { href: "/#faq", title: "FAQ" },
       { href: "/blog/", title: "Blog" },
     ],

--- a/src/utils/configType.ts
+++ b/src/utils/configType.ts
@@ -59,6 +59,8 @@ export type TemplateConfig = {
         links: {
             title: string;
             href: string;
+            /** Dropped on localized homepages — see applyTranslation (#57). */
+            enOnly?: boolean | undefined;
         }[];
         legalLinks: {
             termsAndConditions: boolean;
@@ -77,6 +79,8 @@ export type TemplateConfig = {
         links: {
             title: string;
             href: string;
+            /** Dropped on localized homepages — see applyTranslation (#57). */
+            enOnly?: boolean | undefined;
         }[];
         hideGooglePlay?: boolean | undefined;
         hideAppStore?: boolean | undefined;


### PR DESCRIPTION
Follow-up to #58, which left the tool reachable only from a block two-thirds down the homepage — thin for the one page on this site built to attract people who don't already know the app exists.

## The catch

Nav and footer titles are translated **by array index**:

```ts
title: t.nav.links[i] ?? link.title
```

Adding a fifth entry naively would have shifted every item after it, so "Packing list" would render as "FAQ" in Danish, "FAQ" as "Blog", and the last item would fall back to English. Links now carry an optional `enOnly` flag and are filtered out *before* the positional zip, so all 11 locale files stay untouched.

## Verified against a production build

| Surface | nav / footer |
|---|---|
| `/`, `/blog/`, `/packing-list/` | Features · How it works · **Packing list** · FAQ · Blog |
| `/da/` | Funktioner · Sådan virker det · FAQ · Blog |
| `/ja/` | 機能 · 使い方 · よくある質問 · ブログ |

- Danish nav diffed byte-for-byte against the currently-live page: **identical**.
- All 11 localised homepages contain **0** links to `/packing-list/`.
- Five-item nav fits at 1024px, no horizontal overflow.
- `astro check`: 0 errors, 0 warnings. Build clean, 56 pages.

## Note on testing

Validated against `pnpm build` + `pnpm preview` rather than the Docker dev server. The homepage island doesn't hydrate under Docker dev — reproduced **with the change stashed**, so it is pre-existing and unrelated, but it means Docker dev can't verify navbar behaviour. Production and the production build both hydrate correctly. Worth its own issue alongside the missing `@resvg/resvg-js` in that image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01486FDB6WBDqapdYhBvuVKs