### PR TITLE
Route packing-list traffic to the packing Custom Product Page

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -20,6 +20,16 @@ interface Props {
   bodyClass?: string;
   hideAppBanner?: boolean;
   /**
+   * Send every App Store link on the page to a different listing — used by the
+   * packing-list pages to route their traffic to the packing Custom Product
+   * Page (travel-stories#222). Applies to the navbar CTA, the sticky download
+   * bar and the app banner alike, because all three read `appStoreLink` from
+   * the same ConfigContext. Without it only the in-page CTA would be routed,
+   * and roughly three quarters of the taps on these pages would still land on
+   * the default listing.
+   */
+  appStoreLinkOverride?: string;
+  /**
    * Trail below Home, for sections that aren't the blog. Omit and the layout
    * builds the blog trail it was originally written for.
    */
@@ -39,6 +49,7 @@ const {
   tags = [],
   bodyClass = "",
   hideAppBanner = false,
+  appStoreLinkOverride,
   breadcrumbTrail,
 } = Astro.props;
 
@@ -49,6 +60,7 @@ const config: TemplateConfig = {
     ? appStoreData.artworkUrl512
     : defaultTemplateConfig.logo,
   appStore: toAppStoreMetadata(appStoreData),
+  ...(appStoreLinkOverride ? { appStoreLink: appStoreLinkOverride } : {}),
 };
 
 const canonicalURL = new URL(canonicalPath ?? Astro.url.pathname, Astro.site);

--- a/src/pages/packing-list/[slug].astro
+++ b/src/pages/packing-list/[slug].astro
@@ -54,6 +54,7 @@ const itemListNode = {
   canonicalPath={canonicalPath}
   extraGraphNodes={[itemListNode]}
   hideAppBanner={true}
+  appStoreLinkOverride={defaultTemplateConfig.packingAppStoreLink}
   bodyClass="packing-page"
   breadcrumbTrail={[
     { name: "Packing lists", item: new URL("/packing-list/", Astro.site).href },
@@ -100,7 +101,8 @@ const itemListNode = {
         initialOptions={page.options}
         extras={page.extras}
         heading={page.h1}
-        appStoreLink={defaultTemplateConfig.appStoreLink}
+        appStoreLink={defaultTemplateConfig.packingAppStoreLink ||
+          defaultTemplateConfig.appStoreLink}
         storageKey={`packing-list:${page.slug}`}
       />
     </div>

--- a/src/pages/packing-list/index.astro
+++ b/src/pages/packing-list/index.astro
@@ -88,6 +88,7 @@ const webAppNode = {
   canonicalPath={canonicalPath}
   extraGraphNodes={[webAppNode, itemListNode, faqNode]}
   hideAppBanner={true}
+  appStoreLinkOverride={defaultTemplateConfig.packingAppStoreLink}
   bodyClass="packing-page"
   breadcrumbTrail={[{ name: "Packing lists", item: canonicalURL.href }]}
 >
@@ -117,7 +118,8 @@ const webAppNode = {
       <PackingListGenerator
         client:idle
         initialOptions={DEFAULT_OPTIONS}
-        appStoreLink={defaultTemplateConfig.appStoreLink}
+        appStoreLink={defaultTemplateConfig.packingAppStoreLink ||
+          defaultTemplateConfig.appStoreLink}
         storageKey="packing-list:hub"
       />
     </div>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,6 +18,16 @@ const templateConfig: TemplateConfig = {
   // Geo-neutral: Apple redirects to the visitor's own storefront. The /dk/
   // path routed every international visitor through the Danish store.
   appStoreLink: "https://apps.apple.com/app/id6756801168",
+  // Custom Product Page for packing-list traffic (travel-stories#222). Visitors
+  // arriving on "carry-on only packing list" style queries land on a listing
+  // that leads with the packing checklist and luggage suggestions, instead of
+  // the default page's Trips List / Trip Detail / Widget.
+  //
+  // Apple serves the standard product page for an unknown or not-yet-approved
+  // ppid, so this is safe to ship before review clears. Blank it out to send
+  // packing traffic back to the default listing.
+  packingAppStoreLink:
+    "https://apps.apple.com/app/id6756801168?ppid=7b469e5b-98cd-4ca4-9a82-ff91dbf22712",
   googlePlayLink: "",
   // Component-level strings that localize with the homepage (#22).
   ui: {

--- a/src/utils/configType.ts
+++ b/src/utils/configType.ts
@@ -34,6 +34,8 @@ export type TemplateConfig = {
     showThemeSwitch: boolean;
     googlePlayLink?: string | undefined;
     appStoreLink?: string | undefined;
+    /** Custom Product Page link for packing-list traffic; falls back to appStoreLink. */
+    packingAppStoreLink?: string | undefined;
     termsAndConditions: {
         seo: {
             title: string;


### PR DESCRIPTION
Site half of 12fdk/travel-stories#222. The CPP now exists in App Store Connect (`packing-list-web`, version 1, `WAITING_FOR_REVIEW`) with a packing-led screenshot order across en-US/GB/AU/CA.

## What changed

`packingAppStoreLink` in config, plus an `appStoreLinkOverride` prop on `BlogLayout`.

The prop is the point of this PR. Wiring only the in-page CTA would have missed most of the traffic — the packing pages carry **four** App Store links, and the other three (navbar CTA, sticky download bar, app banner) read `appStoreLink` from `ConfigContext`, not from the generator's props. One override on the layout covers all of them, with no changes to the shared components.

## Verified after build

| Page | App Store links | via CPP |
|---|---:|---:|
| `/packing-list/` | 4 | **4** |
| `/packing-list/carry-on-only-packing-list/` | 4 | **4** |
| `/blog/` (control) | 3 | 0 |
| `/` (control) | 9 | 0 |

Also confirmed the fallback by blanking `packingAppStoreLink` and rebuilding: 0 CPP links, 4 plain App Store links, back to 4/4 on restore.

## Safe to merge now

Apple serves the standard product page for an unknown or not-yet-approved `ppid`, so this does nothing until the page clears review and needs no follow-up deploy when it does. Blanking the config value reverts packing traffic to the default listing.

One note: the homepage HTML contains the string `ppid=` once, inside the serialized Astro island config — it is not a rendered link, and the table above confirms 0 actual hrefs.